### PR TITLE
feat: add Algolia DocSearch, sequential pagination, API reference auto-generation, and architecture overview

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,13 @@
+# Algolia DocSearch credentials
+# Apply for a free DocSearch index at https://docsearch.algolia.com/apply
+# Once approved, Algolia will crawl your deployed site and provide these values.
+#
+# Copy this file to .env.local and fill in your credentials:
+#   cp .env.local.example .env.local
+#
+# Without these variables the search bar renders as a non-functional placeholder.
+# The rest of the site works normally without them.
+
+NEXT_PUBLIC_ALGOLIA_APP_ID=
+NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY=
+NEXT_PUBLIC_ALGOLIA_INDEX_NAME=soroban_zk_std

--- a/frontend/app/docs/api-reference/page.tsx
+++ b/frontend/app/docs/api-reference/page.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import React, { useState } from "react";
+import { DocsLayout } from "@/components/DocsLayout";
+import apiData from "@/lib/api-data.json";
+
+type ApiItem = {
+  kind: string;
+  name: string;
+  doc: string;
+  signature: string;
+};
+
+type Crate = {
+  name: string;
+  path: string;
+  description: string;
+  items: ApiItem[];
+};
+
+const KIND_COLORS: Record<string, string> = {
+  fn: "bg-cyan-100 dark:bg-cyan-900/30 text-cyan-700 dark:text-cyan-300 border-cyan-200 dark:border-cyan-800",
+  struct:
+    "bg-violet-100 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300 border-violet-200 dark:border-violet-800",
+  enum: "bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 border-amber-200 dark:border-amber-800",
+  trait:
+    "bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 border-green-200 dark:border-green-800",
+  type: "bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-300 border-neutral-200 dark:border-neutral-700",
+  const:
+    "bg-rose-100 dark:bg-rose-900/30 text-rose-700 dark:text-rose-300 border-rose-200 dark:border-rose-800",
+};
+
+function KindBadge({ kind }: { kind: string }) {
+  const cls = KIND_COLORS[kind] ?? KIND_COLORS.type;
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold border uppercase tracking-wider ${cls}`}
+    >
+      {kind}
+    </span>
+  );
+}
+
+function ItemCard({ item }: { item: ApiItem }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="border border-neutral-200 dark:border-neutral-800 rounded-xl overflow-hidden transition-colors hover:border-neutral-300 dark:hover:border-neutral-700">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full text-left p-4 flex items-start gap-3 bg-neutral-50 dark:bg-neutral-900/50 hover:bg-neutral-100 dark:hover:bg-neutral-900 transition-colors"
+      >
+        <div className="mt-0.5 shrink-0">
+          <KindBadge kind={item.kind} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="font-bold text-black dark:text-white text-sm font-mono">
+            {item.name}
+          </p>
+          {item.doc && (
+            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1 line-clamp-2">
+              {item.doc}
+            </p>
+          )}
+        </div>
+        <svg
+          className={`w-4 h-4 text-neutral-400 shrink-0 mt-0.5 transition-transform duration-200 ${
+            expanded ? "rotate-180" : ""
+          }`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
+      </button>
+
+      {expanded && (
+        <div className="px-4 pb-4 pt-3 border-t border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950">
+          {item.doc && (
+            <p className="text-sm text-neutral-600 dark:text-neutral-400 mb-3 leading-relaxed">
+              {item.doc}
+            </p>
+          )}
+          <pre className="text-xs font-mono bg-neutral-50 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 rounded-lg p-3 overflow-x-auto text-black dark:text-white whitespace-pre-wrap break-all">
+            {item.signature}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CrateSection({ crate }: { crate: Crate }) {
+  const CRATE_COLORS: Record<string, string> = {
+    "zk-core": "bg-cyan-500",
+    "zk-soroban": "bg-violet-500",
+  };
+  const dot = CRATE_COLORS[crate.name] ?? "bg-neutral-500";
+
+  return (
+    <section className="mb-14">
+      <div className="flex items-center gap-3 mb-2">
+        <span className={`w-2.5 h-2.5 rounded-full ${dot}`} />
+        <h2 className="text-2xl font-bold text-black dark:text-white tracking-tight font-mono">
+          {crate.name}
+        </h2>
+        <span className="text-xs text-neutral-400 dark:text-neutral-500 font-mono">
+          {crate.path}
+        </span>
+      </div>
+      <p className="text-neutral-500 dark:text-neutral-400 text-sm mb-6 ml-5">
+        {crate.description}
+      </p>
+
+      <div className="space-y-2">
+        {crate.items.map((item) => (
+          <ItemCard key={`${crate.name}-${item.name}`} item={item} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default function ApiReferencePage() {
+  const data = apiData as { generated_at: string; version: string; crates: Crate[] };
+
+  return (
+    <DocsLayout>
+      {/* Page Header */}
+      <div className="mb-10">
+        <div className="flex items-center gap-2 mb-3">
+          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-[10px] font-bold bg-cyan-100 dark:bg-cyan-900/30 text-cyan-700 dark:text-cyan-300 border border-cyan-200 dark:border-cyan-800 uppercase tracking-wider">
+            API Reference
+          </span>
+        </div>
+        <h1 className="text-4xl md:text-5xl font-extrabold text-black dark:text-white tracking-tight mb-4">
+          API Reference
+        </h1>
+        <p className="text-lg text-neutral-500 dark:text-neutral-400 leading-relaxed max-w-3xl">
+          Auto-generated from Rust source doc comments. Run{" "}
+          <code className="px-1.5 py-0.5 bg-neutral-100 dark:bg-neutral-800 rounded text-sm font-mono text-black dark:text-white">
+            node scripts/generate-api-docs.mjs
+          </code>{" "}
+          to refresh.
+        </p>
+      </div>
+
+      <hr className="border-neutral-200 dark:border-neutral-800 mb-10" />
+
+      {/* Legend */}
+      <section className="mb-10">
+        <div className="flex flex-wrap gap-2">
+          {Object.entries(KIND_COLORS).map(([kind, cls]) => (
+            <span
+              key={kind}
+              className={`inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold border uppercase tracking-wider ${cls}`}
+            >
+              {kind}
+            </span>
+          ))}
+        </div>
+      </section>
+
+      {/* Crate Sections */}
+      {data.crates.map((crate) => (
+        <CrateSection key={crate.name} crate={crate} />
+      ))}
+
+      {/* Generation Metadata */}
+      <div className="mt-4 pt-6 border-t border-neutral-200 dark:border-neutral-800">
+        <p className="text-xs text-neutral-400 dark:text-neutral-500 font-mono">
+          Generated from source on{" "}
+          {new Date(data.generated_at).toLocaleDateString("en-US", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          })}
+          {" "}· v{data.version}
+        </p>
+      </div>
+    </DocsLayout>
+  );
+}

--- a/frontend/app/docs/architecture/page.tsx
+++ b/frontend/app/docs/architecture/page.tsx
@@ -1,0 +1,477 @@
+"use client";
+
+import React from "react";
+import { DocsLayout } from "@/components/DocsLayout";
+import { CodeBlock } from "@/components/CodeBlock";
+
+export default function ArchitecturePage() {
+  return (
+    <DocsLayout>
+      {/* Page Header */}
+      <div className="mb-10">
+        <div className="flex items-center gap-2 mb-3">
+          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-[10px] font-bold bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-300 border border-neutral-200 dark:border-neutral-700 uppercase tracking-wider">
+            Core Concepts
+          </span>
+        </div>
+        <h1 className="text-4xl md:text-5xl font-extrabold text-black dark:text-white tracking-tight mb-4">
+          Architecture Overview
+        </h1>
+        <p className="text-lg text-neutral-500 dark:text-neutral-400 leading-relaxed max-w-3xl">
+          The Zero-Overhead design philosophy and how the library maps Soroban
+          U256 values to BN254 field elements without heap allocation or runtime
+          cost.
+        </p>
+      </div>
+
+      <hr className="border-neutral-200 dark:border-neutral-800 mb-10" />
+
+      {/* Zero-Overhead Philosophy */}
+      <section className="mb-12">
+        <h2 className="text-2xl font-bold text-black dark:text-white tracking-tight mb-4">
+          The Zero-Overhead Philosophy
+        </h2>
+        <p className="text-neutral-600 dark:text-neutral-400 leading-relaxed mb-4">
+          Soroban-ZK-Std is built on a single constraint: using the library
+          must cost no more than calling the underlying Soroban host functions
+          directly. Every abstraction in the library must compile away entirely.
+          There are no runtime allocations, no dynamic dispatch, and no hidden
+          copies in any hot path.
+        </p>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+          <div className="p-5 rounded-xl border border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-900/50">
+            <h3 className="font-bold text-black dark:text-white mb-2 text-sm">
+              No heap allocation
+            </h3>
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">
+              All conversions use stack-allocated 32-byte arrays. The{" "}
+              <code className="text-xs px-1 py-0.5 bg-neutral-200 dark:bg-neutral-800 rounded">
+                #[no_std]
+              </code>{" "}
+              attribute in <code className="text-xs px-1 py-0.5 bg-neutral-200 dark:bg-neutral-800 rounded">zk-core</code> enforces this.
+            </p>
+          </div>
+          <div className="p-5 rounded-xl border border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-900/50">
+            <h3 className="font-bold text-black dark:text-white mb-2 text-sm">
+              No dynamic dispatch
+            </h3>
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">
+              Traits use static dispatch only. All trait implementations are
+              monomorphized at compile time, resulting in zero vtable overhead.
+            </p>
+          </div>
+          <div className="p-5 rounded-xl border border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-900/50">
+            <h3 className="font-bold text-black dark:text-white mb-2 text-sm">
+              Host delegation
+            </h3>
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">
+              Expensive operations (pairing, Poseidon2) delegate directly to
+              Soroban host functions. The library adds only the marshalling
+              overhead, not the computation.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Crate Layout */}
+      <section className="mb-12">
+        <h2 className="text-2xl font-bold text-black dark:text-white tracking-tight mb-4">
+          Crate Layout
+        </h2>
+        <p className="text-neutral-600 dark:text-neutral-400 leading-relaxed mb-6">
+          The workspace is split into three crates with a strict dependency
+          ordering. Each layer adds only what it needs from the layer below.
+        </p>
+
+        {/* Dependency diagram */}
+        <div className="relative mb-8">
+          <div className="border border-neutral-200 dark:border-neutral-800 rounded-xl overflow-hidden">
+            {/* verifier-sample */}
+            <div className="p-4 bg-amber-50 dark:bg-amber-900/10 border-b border-neutral-200 dark:border-neutral-800">
+              <div className="flex items-center gap-3">
+                <span className="w-2.5 h-2.5 rounded-full bg-amber-500 shrink-0" />
+                <div>
+                  <p className="font-bold text-black dark:text-white text-sm font-mono">
+                    verifier-sample
+                  </p>
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-0.5">
+                    Integration contract. Benchmarks WASM size and gas cost.
+                    Not shipped to production.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Arrow */}
+            <div className="flex justify-center py-2 bg-neutral-50 dark:bg-neutral-900/30 border-b border-neutral-200 dark:border-neutral-800">
+              <span className="text-neutral-400 text-xs font-mono">depends on ↓</span>
+            </div>
+
+            {/* zk-soroban */}
+            <div className="p-4 bg-violet-50 dark:bg-violet-900/10 border-b border-neutral-200 dark:border-neutral-800">
+              <div className="flex items-center gap-3">
+                <span className="w-2.5 h-2.5 rounded-full bg-violet-500 shrink-0" />
+                <div>
+                  <p className="font-bold text-black dark:text-white text-sm font-mono">
+                    zk-soroban
+                  </p>
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-0.5">
+                    Stellar-specific glue. Implements{" "}
+                    <code className="text-xs px-1 bg-neutral-100 dark:bg-neutral-800 rounded">
+                      ZkEnv
+                    </code>
+                    ,{" "}
+                    <code className="text-xs px-1 bg-neutral-100 dark:bg-neutral-800 rounded">
+                      HostConvert
+                    </code>
+                    , pairing, and Poseidon2. Depends on{" "}
+                    <code className="text-xs px-1 bg-neutral-100 dark:bg-neutral-800 rounded">
+                      soroban-sdk
+                    </code>{" "}
+                    and{" "}
+                    <code className="text-xs px-1 bg-neutral-100 dark:bg-neutral-800 rounded">
+                      zk-core
+                    </code>
+                    .
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Arrow */}
+            <div className="flex justify-center py-2 bg-neutral-50 dark:bg-neutral-900/30 border-b border-neutral-200 dark:border-neutral-800">
+              <span className="text-neutral-400 text-xs font-mono">depends on ↓</span>
+            </div>
+
+            {/* zk-core */}
+            <div className="p-4 bg-cyan-50 dark:bg-cyan-900/10">
+              <div className="flex items-center gap-3">
+                <span className="w-2.5 h-2.5 rounded-full bg-cyan-500 shrink-0" />
+                <div>
+                  <p className="font-bold text-black dark:text-white text-sm font-mono">
+                    zk-core
+                  </p>
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-0.5">
+                    Pure math. Field arithmetic, elliptic curve operations, and
+                    type definitions. Marked{" "}
+                    <code className="text-xs px-1 bg-neutral-100 dark:bg-neutral-800 rounded">
+                      #[no_std]
+                    </code>
+                    . No Soroban dependency.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <p className="text-neutral-600 dark:text-neutral-400 leading-relaxed text-sm">
+          This separation matters for WASM binary size. Only{" "}
+          <code className="px-1.5 py-0.5 bg-neutral-100 dark:bg-neutral-800 rounded text-sm font-mono">
+            zk-soroban
+          </code>{" "}
+          and{" "}
+          <code className="px-1.5 py-0.5 bg-neutral-100 dark:bg-neutral-800 rounded text-sm font-mono">
+            zk-core
+          </code>{" "}
+          are linked into production contracts. Because{" "}
+          <code className="px-1.5 py-0.5 bg-neutral-100 dark:bg-neutral-800 rounded text-sm font-mono">
+            zk-core
+          </code>{" "}
+          is{" "}
+          <code className="px-1.5 py-0.5 bg-neutral-100 dark:bg-neutral-800 rounded text-sm font-mono">
+            no_std
+          </code>
+          , it contributes no standard library code to the final WASM, keeping
+          the binary under Soroban&apos;s 64 KB limit.
+        </p>
+      </section>
+
+      {/* U256 to Fr Mapping */}
+      <section className="mb-12">
+        <h2 className="text-2xl font-bold text-black dark:text-white tracking-tight mb-4">
+          U256 to Fr Field Mapping
+        </h2>
+        <p className="text-neutral-600 dark:text-neutral-400 leading-relaxed mb-4">
+          The most important bridging operation in the library converts
+          Soroban&apos;s host-managed{" "}
+          <code className="px-1.5 py-0.5 bg-neutral-100 dark:bg-neutral-800 rounded text-sm font-mono">
+            U256
+          </code>{" "}
+          type into an internally-validated BN254 scalar field element{" "}
+          <code className="px-1.5 py-0.5 bg-neutral-100 dark:bg-neutral-800 rounded text-sm font-mono">
+            Fr
+          </code>
+          . The design constraint is that this must never allocate and must
+          never panic.
+        </p>
+
+        <div className="p-5 rounded-xl bg-neutral-50 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 mb-6">
+          <p className="text-sm font-bold text-black dark:text-white mb-3">
+            Why two separate U256 types?
+          </p>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-neutral-600 dark:text-neutral-400">
+            <div>
+              <p className="font-semibold text-black dark:text-white mb-1">
+                <code className="text-xs px-1 py-0.5 bg-neutral-200 dark:bg-neutral-800 rounded">
+                  soroban_sdk::U256
+                </code>
+              </p>
+              <p>
+                An opaque handle to a 256-bit integer managed by the Soroban
+                host VM. Cannot be inspected directly from guest code — values
+                must be extracted via host calls (e.g.{" "}
+                <code className="text-xs">to_be_bytes()</code>).
+              </p>
+            </div>
+            <div>
+              <p className="font-semibold text-black dark:text-white mb-1">
+                <code className="text-xs px-1 py-0.5 bg-neutral-200 dark:bg-neutral-800 rounded">
+                  ethnum::u256
+                </code>
+              </p>
+              <p>
+                A concrete, value-type 256-bit integer that lives on the guest
+                stack. Required for field arithmetic, since BN254 operations
+                need direct bit manipulation.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <p className="text-neutral-600 dark:text-neutral-400 leading-relaxed mb-4">
+          The conversion path through{" "}
+          <code className="px-1.5 py-0.5 bg-neutral-100 dark:bg-neutral-800 rounded text-sm font-mono">
+            HostConvert::fr_from_u256
+          </code>{" "}
+          performs four steps:
+        </p>
+
+        <CodeBlock
+          code={`impl HostConvert for Env {
+    #[inline(always)]
+    fn fr_from_u256(&self, val: U256) -> Result<Fr, ZkError> {
+        // Step 1: allocate 32 bytes on the stack (no heap)
+        let mut bytes = [0u8; 32];
+
+        // Step 2: copy host-managed U256 out as big-endian bytes
+        val.to_be_bytes().copy_into_slice(&mut bytes);
+
+        // Step 3: reinterpret as ethnum::u256 — same bit layout, zero copy
+        let raw = eth_u256::from_be_bytes(bytes);
+
+        // Step 4: validate against the BN254 modulus r, return Fr or error
+        Fr::safe_from(raw)
+    }
+}`}
+          language="rust"
+          filename="crates/zk-soroban/src/lib.rs"
+        />
+
+        <div className="mt-6 overflow-x-auto">
+          <table className="w-full text-sm border-collapse">
+            <thead>
+              <tr className="border-b border-neutral-200 dark:border-neutral-800">
+                <th className="text-left py-3 pr-6 font-bold text-black dark:text-white">
+                  Step
+                </th>
+                <th className="text-left py-3 pr-6 font-bold text-black dark:text-white">
+                  Operation
+                </th>
+                <th className="text-left py-3 font-bold text-black dark:text-white">
+                  Cost
+                </th>
+              </tr>
+            </thead>
+            <tbody className="text-neutral-600 dark:text-neutral-400">
+              <tr className="border-b border-neutral-100 dark:border-neutral-800/50">
+                <td className="py-3 pr-6 font-mono text-xs">1</td>
+                <td className="py-3 pr-6">
+                  Stack allocate <code className="text-xs px-1 bg-neutral-100 dark:bg-neutral-800 rounded">[u8; 32]</code>
+                </td>
+                <td className="py-3 font-mono text-xs text-green-600 dark:text-green-400">
+                  0 instructions
+                </td>
+              </tr>
+              <tr className="border-b border-neutral-100 dark:border-neutral-800/50">
+                <td className="py-3 pr-6 font-mono text-xs">2</td>
+                <td className="py-3 pr-6">
+                  <code className="text-xs px-1 bg-neutral-100 dark:bg-neutral-800 rounded">val.to_be_bytes()</code>{" "}
+                  host call
+                </td>
+                <td className="py-3 font-mono text-xs">1 host call</td>
+              </tr>
+              <tr className="border-b border-neutral-100 dark:border-neutral-800/50">
+                <td className="py-3 pr-6 font-mono text-xs">3</td>
+                <td className="py-3 pr-6">
+                  <code className="text-xs px-1 bg-neutral-100 dark:bg-neutral-800 rounded">u256::from_be_bytes</code>{" "}
+                  — memcpy of 32 bytes
+                </td>
+                <td className="py-3 font-mono text-xs">32 bytes copied</td>
+              </tr>
+              <tr>
+                <td className="py-3 pr-6 font-mono text-xs">4</td>
+                <td className="py-3 pr-6">
+                  <code className="text-xs px-1 bg-neutral-100 dark:bg-neutral-800 rounded">overflowing_sub</code>{" "}
+                  range check
+                </td>
+                <td className="py-3 font-mono text-xs text-green-600 dark:text-green-400">
+                  ~2 instructions
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div className="mt-6 p-5 rounded-xl bg-cyan-50 dark:bg-cyan-900/10 border border-cyan-200 dark:border-cyan-800/30">
+          <p className="text-sm text-cyan-800 dark:text-cyan-300">
+            <strong>Why overflowing_sub for range check?</strong> The BN254
+            scalar field modulus{" "}
+            <code className="text-xs">r</code> fits in 254 bits. Calling{" "}
+            <code className="text-xs">val.overflowing_sub(r)</code> returns{" "}
+            <code className="text-xs">(_, true)</code> (underflow) if and only
+            if <code className="text-xs">val {"<"} r</code>, which is exactly
+            the validity condition for an Fr element. This avoids a comparison
+            instruction and is branchless on most architectures.
+          </p>
+        </div>
+      </section>
+
+      {/* BN254 Field Parameters */}
+      <section className="mb-12">
+        <h2 className="text-2xl font-bold text-black dark:text-white tracking-tight mb-4">
+          BN254 Field Parameters
+        </h2>
+        <p className="text-neutral-600 dark:text-neutral-400 leading-relaxed mb-4">
+          The library is pinned to BN254 (also called alt-bn128), which is the
+          pairing-friendly elliptic curve supported by Soroban&apos;s CAP-0075
+          host functions. The two critical field moduli are:
+        </p>
+
+        <CodeBlock
+          code={`// Scalar field modulus r — order of the BN254 generator group G1/G2
+// Valid Fr elements are in [0, r)
+pub const FR_MODULUS: u256 = u256::from_words(
+    0x30644e72e131a029b85045b68181585d_u128,
+    0x2833e84879b9709143e1f593f0000001_u128,
+);
+// r ≈ 2^254, specifically:
+// r = 21888242871839275222246405745257275088548364400416034343698204186575808495617
+
+// Base field modulus q — coordinates of G1/G2 points live in [0, q)
+pub const FQ_MODULUS: u256 = u256::from_words(
+    0x30644e72e131a029b85045b68181585d_u128,
+    0x97816a916871ca8d3c208c16d87cfd47_u128,
+);
+// q ≈ 2^254, specifically:
+// q = 21888242871839275222246405745257275088696311157297823662689037894645226208583`}
+          language="rust"
+          filename="crates/zk-core/src/lib.rs"
+        />
+
+        <p className="text-neutral-600 dark:text-neutral-400 leading-relaxed mt-4 mb-4">
+          The two moduli share the same high 128 bits{" "}
+          <code className="px-1.5 py-0.5 bg-neutral-100 dark:bg-neutral-800 rounded text-sm font-mono">
+            0x30644e72...
+          </code>
+          . They differ only in the low 128 bits, which is why field elements
+          from Fr and Fq look similar in hex but have different validity ranges.
+          Every input to the library is validated against the appropriate
+          modulus before any arithmetic is performed.
+        </p>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="p-5 rounded-xl border border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-900/50">
+            <h3 className="font-bold text-black dark:text-white mb-2 text-sm flex items-center gap-2">
+              <span className="w-2 h-2 rounded-full bg-violet-500" />
+              Fr — Scalar Field
+            </h3>
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">
+              Exponents and scalars used in elliptic curve scalar
+              multiplication. ZK proof inputs (witnesses, public signals) are
+              Fr elements.
+            </p>
+          </div>
+          <div className="p-5 rounded-xl border border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-900/50">
+            <h3 className="font-bold text-black dark:text-white mb-2 text-sm flex items-center gap-2">
+              <span className="w-2 h-2 rounded-full bg-cyan-500" />
+              Fq — Base Field
+            </h3>
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">
+              Coordinates of points on the G1 and G2 curves. The affine
+              coordinates (x, y) of G1Affine live in Fq; G2Affine coordinates
+              live in the degree-2 extension Fq².
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Design Constraints */}
+      <section className="mb-12">
+        <h2 className="text-2xl font-bold text-black dark:text-white tracking-tight mb-4">
+          Soroban Design Constraints
+        </h2>
+        <p className="text-neutral-600 dark:text-neutral-400 leading-relaxed mb-6">
+          Every architectural decision in the library is shaped by three hard
+          limits imposed by the Soroban VM:
+        </p>
+
+        <div className="space-y-4">
+          <div className="flex gap-4 p-5 rounded-xl border border-neutral-200 dark:border-neutral-800">
+            <div className="text-2xl font-extrabold text-black dark:text-white w-24 shrink-0 font-mono">
+              64 KB
+            </div>
+            <div>
+              <p className="font-bold text-black dark:text-white text-sm mb-1">
+                WASM binary limit
+              </p>
+              <p className="text-sm text-neutral-500 dark:text-neutral-400">
+                Standard Rust ZK crates (arkworks, bellman) produce binaries
+                of 1–5 MB. The{" "}
+                <code className="text-xs px-1 bg-neutral-100 dark:bg-neutral-800 rounded">
+                  no_std
+                </code>{" "}
+                attribute and careful dependency selection keep zk-core under
+                budget. The verifier-sample contract measures final WASM size
+                in CI.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex gap-4 p-5 rounded-xl border border-neutral-200 dark:border-neutral-800">
+            <div className="text-2xl font-extrabold text-black dark:text-white w-24 shrink-0 font-mono">
+              400 M
+            </div>
+            <div>
+              <p className="font-bold text-black dark:text-white text-sm mb-1">
+                Instruction budget per transaction
+              </p>
+              <p className="text-sm text-neutral-500 dark:text-neutral-400">
+                A software BN254 pairing check costs ~380 M instructions,
+                leaving no budget for anything else. The library delegates
+                pairings to the CAP-0075 host function, which costs ~2 M
+                instructions regardless of the number of pairs.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex gap-4 p-5 rounded-xl border border-neutral-200 dark:border-neutral-800">
+            <div className="text-2xl font-extrabold text-black dark:text-white w-24 shrink-0 font-mono">
+              0 B
+            </div>
+            <div>
+              <p className="font-bold text-black dark:text-white text-sm mb-1">
+                Heap allocation in hot paths
+              </p>
+              <p className="text-sm text-neutral-500 dark:text-neutral-400">
+                Heap allocation in WASM guest code is expensive because it
+                requires crossing the host-guest boundary. All field conversions
+                and validations in zk-core use stack memory only.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </DocsLayout>
+  );
+}

--- a/frontend/app/docs/cap0075/page.tsx
+++ b/frontend/app/docs/cap0075/page.tsx
@@ -167,23 +167,6 @@ fn verify_identity(env: &Env) -> Result<bool, ZkError> {
         </div>
       </section>
 
-      {/* Next Steps */}
-      <section>
-        <div className="flex items-center justify-between pt-8 border-t border-neutral-200 dark:border-neutral-800">
-          <a
-            href="/docs"
-            className="text-sm text-neutral-500 dark:text-neutral-400 hover:text-black dark:hover:text-white transition-colors"
-          >
-            ← Introduction
-          </a>
-          <a
-            href="/docs/polynomial-operations"
-            className="text-sm text-neutral-500 dark:text-neutral-400 hover:text-black dark:hover:text-white transition-colors"
-          >
-            Polynomial Operations →
-          </a>
-        </div>
-      </section>
     </DocsLayout>
   );
 }

--- a/frontend/app/docs/polynomial-operations/page.tsx
+++ b/frontend/app/docs/polynomial-operations/page.tsx
@@ -265,23 +265,6 @@ assert_eq!(product.evaluate(u256::from(1u8)), u256::from(54u8));`}
         </div>
       </section>
 
-      {/* Navigation */}
-      <section>
-        <div className="flex items-center justify-between pt-8 border-t border-neutral-200 dark:border-neutral-800">
-          <a
-            href="/docs/cap0075"
-            className="text-sm text-neutral-500 dark:text-neutral-400 hover:text-black dark:hover:text-white transition-colors"
-          >
-            ← CAP-0075 Integration
-          </a>
-          <a
-            href="/docs/pairing"
-            className="text-sm text-neutral-500 dark:text-neutral-400 hover:text-black dark:hover:text-white transition-colors"
-          >
-            Pairing API →
-          </a>
-        </div>
-      </section>
     </DocsLayout>
   );
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,3 +1,5 @@
+@import "@docsearch/css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -46,4 +48,98 @@
     color: hsl(var(--text-primary));
     transition: background-color 0.3s ease, color 0.3s ease;
   }
+}
+
+/* DocSearch theme overrides — matches the existing light/dark palette */
+:root {
+  --docsearch-primary-color: #000000;
+  --docsearch-text-color: #171717;
+  --docsearch-spacing: 12px;
+  --docsearch-icon-stroke-width: 1.4;
+  --docsearch-highlight-color: var(--docsearch-primary-color);
+  --docsearch-muted-color: #737373;
+  --docsearch-container-background: rgba(0, 0, 0, 0.5);
+  --docsearch-icon-color: #737373;
+  --docsearch-modal-background: #fafafa;
+  --docsearch-modal-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+  --docsearch-searchbox-background: #f5f5f5;
+  --docsearch-searchbox-focus-background: #ffffff;
+  --docsearch-searchbox-shadow: none;
+  --docsearch-hit-color: #404040;
+  --docsearch-hit-active-color: #ffffff;
+  --docsearch-hit-background: #ffffff;
+  --docsearch-hit-shadow: none;
+  --docsearch-key-gradient: linear-gradient(#f5f5f5, #e5e5e5);
+  --docsearch-key-shadow: none;
+  --docsearch-footer-background: #ffffff;
+  --docsearch-footer-shadow: 0 -1px 0 #e5e5e5;
+  --docsearch-logo-color: #737373;
+}
+
+.dark {
+  --docsearch-primary-color: #ffffff;
+  --docsearch-text-color: #f5f5f5;
+  --docsearch-muted-color: #a3a3a3;
+  --docsearch-container-background: rgba(0, 0, 0, 0.7);
+  --docsearch-icon-color: #a3a3a3;
+  --docsearch-modal-background: #0a0a0a;
+  --docsearch-modal-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  --docsearch-searchbox-background: #171717;
+  --docsearch-searchbox-focus-background: #262626;
+  --docsearch-hit-color: #d4d4d4;
+  --docsearch-hit-active-color: #ffffff;
+  --docsearch-hit-background: #171717;
+  --docsearch-key-gradient: linear-gradient(#262626, #171717);
+  --docsearch-footer-background: #0a0a0a;
+  --docsearch-footer-shadow: 0 -1px 0 #262626;
+  --docsearch-logo-color: #a3a3a3;
+}
+
+/* Make the DocSearch button match the existing search-input style */
+.docsearch-container .DocSearch-Button {
+  width: 100%;
+  height: 2.25rem;
+  padding: 0 0.75rem 0 2.5rem;
+  border-radius: 0.75rem;
+  background-color: rgb(250 250 250);
+  border: 1px solid rgb(229 229 229);
+  color: rgb(163 163 163);
+  font-size: 0.875rem;
+  box-shadow: none;
+  justify-content: flex-start;
+  gap: 0;
+}
+
+.dark .docsearch-container .DocSearch-Button {
+  background-color: rgb(10 10 10);
+  border-color: rgb(38 38 38);
+  color: rgb(115 115 115);
+}
+
+.docsearch-container .DocSearch-Button:hover {
+  background-color: rgb(245 245 245);
+  border-color: rgb(212 212 212);
+  box-shadow: none;
+}
+
+.dark .docsearch-container .DocSearch-Button:hover {
+  background-color: rgb(23 23 23);
+  border-color: rgb(64 64 64);
+}
+
+.docsearch-container .DocSearch-Button .DocSearch-Search-Icon {
+  position: absolute;
+  left: 0.75rem;
+  width: 1rem;
+  height: 1rem;
+  color: rgb(163 163 163);
+}
+
+.docsearch-container .DocSearch-Button-Placeholder {
+  font-size: 0.875rem;
+  padding: 0 0.5rem;
+}
+
+.docsearch-container .DocSearch-Button-Keys {
+  margin-left: auto;
 }

--- a/frontend/components/DocSearch.tsx
+++ b/frontend/components/DocSearch.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import React from "react";
+import dynamic from "next/dynamic";
+
+const appId = process.env.NEXT_PUBLIC_ALGOLIA_APP_ID ?? "";
+const apiKey = process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY ?? "";
+const indexName =
+  process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME ?? "soroban_zk_std";
+
+const AlgoliaDocSearch = dynamic(
+  () => import("@docsearch/react").then((mod) => mod.DocSearch),
+  { ssr: false }
+);
+
+interface DocSearchProps {
+  className?: string;
+}
+
+export function DocSearch({ className }: DocSearchProps) {
+  if (!appId || !apiKey) {
+    return (
+      <div
+        className={`relative w-full group ${className ?? ""}`}
+        title="Set NEXT_PUBLIC_ALGOLIA_APP_ID and NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY to enable search"
+      >
+        <svg
+          className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-neutral-400 dark:text-neutral-500"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+          />
+        </svg>
+        <div className="w-full pl-10 pr-16 py-2 text-sm bg-neutral-50 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 rounded-xl text-neutral-400 dark:text-neutral-500 cursor-default select-none">
+          Search documentation...
+        </div>
+        <kbd className="absolute right-3 top-1/2 -translate-y-1/2 hidden lg:inline-flex items-center px-1.5 py-0.5 text-[10px] font-mono font-bold text-neutral-400 dark:text-neutral-500 bg-neutral-100 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded">
+          ⌘K
+        </kbd>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`docsearch-container w-full ${className ?? ""}`}>
+      <AlgoliaDocSearch
+        appId={appId}
+        apiKey={apiKey}
+        indexName={indexName}
+        placeholder="Search documentation..."
+        translations={{
+          button: {
+            buttonText: "Search documentation...",
+            buttonAriaLabel: "Search documentation",
+          },
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/components/DocsLayout.tsx
+++ b/frontend/components/DocsLayout.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import { Navbar } from "./Navbar";
 import { Sidebar } from "./Sidebar";
+import { PrevNextNav } from "./PrevNextNav";
 
 interface DocsLayoutProps {
   children: React.ReactNode;
@@ -25,6 +26,7 @@ export function DocsLayout({ children }: DocsLayoutProps) {
         <main className="flex-1 min-w-0">
           <div className="max-w-4xl mx-auto px-6 md:px-8 py-10 md:py-14">
             {children}
+            <PrevNextNav />
           </div>
 
           {/* Footer */}

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import Link from "next/link";
 import { ThemeToggle } from "./theme-toggle";
+import { DocSearch } from "./DocSearch";
 
 interface NavbarProps {
   onToggleSidebar: () => void;
@@ -41,26 +42,9 @@ export function Navbar({ onToggleSidebar }: NavbarProps) {
           </Link>
         </div>
 
-        {/* Center: Search (desktop) */}
+        {/* Center: DocSearch (desktop) */}
         <div className="hidden md:flex flex-1 max-w-md mx-8">
-          <div className="relative w-full group">
-            <svg
-              className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-neutral-400 dark:text-neutral-500 group-focus-within:text-black dark:group-focus-within:text-white transition-colors"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-            </svg>
-            <input
-              type="text"
-              placeholder="Search documentation..."
-              className="w-full pl-10 pr-4 py-2 text-sm bg-neutral-50 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 rounded-xl text-black dark:text-white placeholder-neutral-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-black/10 dark:focus:ring-white/10 focus:border-neutral-300 dark:focus:border-neutral-700 transition-all duration-200"
-            />
-            <kbd className="absolute right-3 top-1/2 -translate-y-1/2 hidden lg:inline-flex items-center px-1.5 py-0.5 text-[10px] font-mono font-bold text-neutral-400 dark:text-neutral-500 bg-neutral-100 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded">
-              ⌘K
-            </kbd>
-          </div>
+          <DocSearch />
         </div>
 
         {/* Right: Actions */}

--- a/frontend/components/PrevNextNav.tsx
+++ b/frontend/components/PrevNextNav.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import React from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { getFlatNavItems } from "@/lib/navigation";
+
+export function PrevNextNav() {
+  const pathname = usePathname();
+  const items = getFlatNavItems();
+  const idx = items.findIndex((item) => item.href === pathname);
+
+  const prev = idx > 0 ? items[idx - 1] : null;
+  const next = idx !== -1 && idx < items.length - 1 ? items[idx + 1] : null;
+
+  if (!prev && !next) return null;
+
+  return (
+    <div className="flex items-center justify-between pt-8 mt-8 border-t border-neutral-200 dark:border-neutral-800">
+      <div>
+        {prev ? (
+          <Link href={prev.href} className="group inline-flex flex-col text-sm">
+            <span className="text-xs text-neutral-400 dark:text-neutral-500 mb-1 uppercase tracking-widest font-semibold">
+              Previous
+            </span>
+            <span className="text-neutral-600 dark:text-neutral-400 group-hover:text-black dark:group-hover:text-white transition-colors duration-150">
+              &larr; {prev.title}
+            </span>
+          </Link>
+        ) : (
+          <div />
+        )}
+      </div>
+
+      <div className="text-right">
+        {next ? (
+          <Link href={next.href} className="group inline-flex flex-col text-sm">
+            <span className="text-xs text-neutral-400 dark:text-neutral-500 mb-1 uppercase tracking-widest font-semibold">
+              Next
+            </span>
+            <span className="text-neutral-600 dark:text-neutral-400 group-hover:text-black dark:group-hover:text-white transition-colors duration-150">
+              {next.title} &rarr;
+            </span>
+          </Link>
+        ) : (
+          <div />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -3,48 +3,7 @@
 import React, { useState } from "react";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
-
-interface NavItem {
-  title: string;
-  href?: string;
-  children?: NavItem[];
-}
-
-const navigation: NavItem[] = [
-  {
-    title: "Getting Started",
-    children: [
-      { title: "Introduction", href: "/docs" },
-      { title: "Installation", href: "/docs/installation" },
-      { title: "Quick Start", href: "/docs/quick-start" },
-    ],
-  },
-  {
-    title: "Core Concepts",
-    children: [
-      { title: "Field Arithmetic", href: "/docs/field-arithmetic" },
-      { title: "Elliptic Curves", href: "/docs/elliptic-curves" },
-      { title: "Scalar Validation", href: "/docs/scalar-validation" },
-    ],
-  },
-  {
-    title: "API Reference",
-    children: [
-      { title: "Polynomial Operations", href: "/docs/polynomial-operations" },
-      { title: "Pairing", href: "/docs/pairing" },
-      { title: "Poseidon2", href: "/docs/poseidon2" },
-      { title: "ElGamal Encryption", href: "/docs/elgamal" },
-    ],
-  },
-  {
-    title: "Guides",
-    children: [
-      { title: "CAP-0075 Integration", href: "/docs/cap0075" },
-      { title: "ASP Integration", href: "/docs/asp-integration" },
-      { title: "Shielded Assets", href: "/docs/shielded-assets" },
-    ],
-  },
-];
+import { navigation, NavItem } from "@/lib/navigation";
 
 function ChevronIcon({ open }: { open: boolean }) {
   return (

--- a/frontend/lib/api-data.json
+++ b/frontend/lib/api-data.json
@@ -1,0 +1,104 @@
+{
+  "generated_at": "2026-05-29T00:00:00Z",
+  "version": "1.0.0",
+  "crates": [
+    {
+      "name": "zk-core",
+      "path": "crates/zk-core",
+      "description": "Pure cryptographic math. No Soroban dependencies. Compiles to no_std.",
+      "items": [
+        {
+          "kind": "enum",
+          "name": "ZkError",
+          "doc": "Errors returned by zero-knowledge conversion and validation operations.",
+          "signature": "pub enum ZkError"
+        },
+        {
+          "kind": "struct",
+          "name": "Fr",
+          "doc": "A BN254 scalar field element guaranteed to be in the range [0, r). Construct exclusively via SafeFrom to enforce field bounds without panicking.",
+          "signature": "pub struct Fr(u256)"
+        },
+        {
+          "kind": "struct",
+          "name": "G1Affine",
+          "doc": "A BN254 G1 point in affine coordinates (x, y).",
+          "signature": "pub struct G1Affine { pub x: u256, pub y: u256 }"
+        },
+        {
+          "kind": "struct",
+          "name": "G1Projective",
+          "doc": "A BN254 G1 point in projective Jacobian coordinates (X:Y:Z). Internal representation used for efficient scalar multiplication.",
+          "signature": "pub struct G1Projective { pub x: u256, pub y: u256, pub z: u256 }"
+        },
+        {
+          "kind": "trait",
+          "name": "SafeFrom",
+          "doc": "Constant-time, fallible conversion into a cryptographic type. Implemented for Fr from u256 to enforce BN254 field bounds without panicking.",
+          "signature": "pub trait SafeFrom<T>: Sized"
+        },
+        {
+          "kind": "struct",
+          "name": "Bn254",
+          "doc": "The BN254 elliptic curve group parameters and arithmetic operations. Provides modular arithmetic in both Fr (scalar field) and Fq (base field).",
+          "signature": "pub struct Bn254"
+        },
+        {
+          "kind": "struct",
+          "name": "ElGamalCiphertext",
+          "doc": "An ElGamal ciphertext consisting of two G1 points (c1, c2). Used for shielded and private balance encryption.",
+          "signature": "pub struct ElGamalCiphertext { pub c1: G1Affine, pub c2: G1Affine }"
+        }
+      ]
+    },
+    {
+      "name": "zk-soroban",
+      "path": "crates/zk-soroban",
+      "description": "Stellar integration. Traits that extend the Soroban Env, host-function mappings, and XDR conversion.",
+      "items": [
+        {
+          "kind": "fn",
+          "name": "validate_soroban_scalar",
+          "doc": "Validates a Soroban U256 as a BN254 scalar. Prevents out-of-bounds field element errors in ZK verifiers by checking val < r.",
+          "signature": "pub fn validate_soroban_scalar(env: &Env, val: U256) -> bool"
+        },
+        {
+          "kind": "trait",
+          "name": "ZkEnv",
+          "doc": "Extension trait that adds ZK validation methods directly to the Soroban Env. Implemented for Env.",
+          "signature": "pub trait ZkEnv"
+        },
+        {
+          "kind": "trait",
+          "name": "HostConvert",
+          "doc": "Zero-copy conversion from a Soroban host-managed U256 into a validated BN254 Fr field element. The conversion performs a stack-only big-endian byte reinterpretation with no heap allocation, then delegates range validation to Fr::safe_from.",
+          "signature": "pub trait HostConvert"
+        },
+        {
+          "kind": "struct",
+          "name": "G2Affine",
+          "doc": "A BN254 G2 point in affine coordinates (X, Y). Coordinates are elements of the degree-2 extension field Fq^2, represented as a + b*u where the first tuple element is the real part (c0) and the second is the imaginary part (c1).",
+          "signature": "pub struct G2Affine { pub x: (u256, u256), pub y: (u256, u256) }"
+        },
+        {
+          "kind": "fn",
+          "name": "pairing_check",
+          "doc": "Evaluates the BN254 multi-pairing product e(A1, B1) * ... * e(An, Bn) == 1. Delegates to the CAP-0075 host function so the entire check costs ~2M instructions regardless of pair count.",
+          "signature": "pub fn pairing_check(env: &Env, pairs: &[(G1Affine, G2Affine)]) -> Result<bool, ZkError>"
+        },
+        {
+          "kind": "struct",
+          "name": "Poseidon2Sponge",
+          "doc": "Poseidon2 sponge over BN254 Fr (t=3, rate=2, capacity=1). Calls env.crypto_hazmat().poseidon2_permutation() directly so the permutation runs as a single host call with no guest-side loop overhead.",
+          "signature": "pub struct Poseidon2Sponge"
+        },
+        {
+          "kind": "fn",
+          "name": "hash_to_field",
+          "doc": "Hash a slice of BN254 Fr field elements to a single field element. Compatible with Noir and Circom Poseidon2 constraints (t=3, d=5, rate=2). Uses capacity-zero sponge initialisation.",
+          "signature": "pub fn hash_to_field(env: &Env, inputs: &[U256]) -> U256"
+        }
+      ]
+    }
+  ]
+}

--- a/frontend/lib/navigation.ts
+++ b/frontend/lib/navigation.ts
@@ -1,0 +1,57 @@
+export interface NavItem {
+  title: string;
+  href?: string;
+  children?: NavItem[];
+}
+
+export const navigation: NavItem[] = [
+  {
+    title: "Getting Started",
+    children: [
+      { title: "Introduction", href: "/docs" },
+      { title: "Installation", href: "/docs/installation" },
+      { title: "Quick Start", href: "/docs/quick-start" },
+    ],
+  },
+  {
+    title: "Core Concepts",
+    children: [
+      { title: "Architecture Overview", href: "/docs/architecture" },
+      { title: "Field Arithmetic", href: "/docs/field-arithmetic" },
+      { title: "Elliptic Curves", href: "/docs/elliptic-curves" },
+      { title: "Scalar Validation", href: "/docs/scalar-validation" },
+    ],
+  },
+  {
+    title: "API Reference",
+    children: [
+      { title: "API Reference", href: "/docs/api-reference" },
+      { title: "Polynomial Operations", href: "/docs/polynomial-operations" },
+      { title: "Pairing", href: "/docs/pairing" },
+      { title: "Poseidon2", href: "/docs/poseidon2" },
+      { title: "ElGamal Encryption", href: "/docs/elgamal" },
+    ],
+  },
+  {
+    title: "Guides",
+    children: [
+      { title: "CAP-0075 Integration", href: "/docs/cap0075" },
+      { title: "ASP Integration", href: "/docs/asp-integration" },
+      { title: "Shielded Assets", href: "/docs/shielded-assets" },
+    ],
+  },
+];
+
+export function getFlatNavItems(): { title: string; href: string }[] {
+  const result: { title: string; href: string }[] = [];
+  for (const section of navigation) {
+    if (section.children) {
+      for (const child of section.children) {
+        if (child.href) {
+          result.push({ title: child.title, href: child.href });
+        }
+      }
+    }
+  }
+  return result;
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,11 +4,15 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "prebuild": "node scripts/generate-api-docs.mjs",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "generate-api-docs": "node scripts/generate-api-docs.mjs"
   },
   "dependencies": {
+    "@docsearch/css": "^3.6.1",
+    "@docsearch/react": "^3.6.1",
     "lucide-react": "^1.16.0",
     "next": "14.2.3",
     "next-themes": "^0.4.6",

--- a/frontend/scripts/generate-api-docs.mjs
+++ b/frontend/scripts/generate-api-docs.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * generate-api-docs.mjs
+ *
+ * Ingests Rust source files from the monorepo and emits lib/api-data.json.
+ * Parses public items (fn, struct, enum, trait, type, const) and their
+ * associated triple-slash doc comments.
+ *
+ * Usage:
+ *   node scripts/generate-api-docs.mjs
+ *
+ * Run automatically via the `prebuild` npm script defined in package.json.
+ * Output: frontend/lib/api-data.json
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from "fs";
+import { resolve, dirname, join, extname } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const REPO_ROOT = resolve(__dirname, "../../");
+const OUT_FILE = resolve(__dirname, "../lib/api-data.json");
+
+const CRATES = [
+  {
+    name: "zk-core",
+    srcPath: join(REPO_ROOT, "crates/zk-core/src"),
+    description:
+      "Pure cryptographic math. No Soroban dependencies. Compiles to no_std.",
+  },
+  {
+    name: "zk-soroban",
+    srcPath: join(REPO_ROOT, "crates/zk-soroban/src"),
+    description:
+      "Stellar integration. Traits that extend the Soroban Env, host-function mappings, and XDR conversion.",
+  },
+];
+
+function walkDir(dir) {
+  const files = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      files.push(...walkDir(full));
+    } else if (extname(entry) === ".rs") {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function collectDocLines(lines, itemLineIndex) {
+  const docs = [];
+  for (let i = itemLineIndex - 1; i >= 0; i--) {
+    const t = lines[i].trim();
+    if (t.startsWith("///")) {
+      docs.unshift(t.replace(/^\/\/\/\s?/, ""));
+    } else if (t === "" || t.startsWith("#[") || t.startsWith("//!")) {
+      break;
+    } else {
+      break;
+    }
+  }
+  return docs.join(" ").trim();
+}
+
+function extractSignature(lines, startIndex) {
+  let sig = "";
+  for (let i = startIndex; i < Math.min(startIndex + 10, lines.length); i++) {
+    const line = lines[i];
+    sig += (i === startIndex ? "" : " ") + line.trim();
+    const braceIdx = sig.indexOf("{");
+    if (braceIdx !== -1) {
+      sig = sig.substring(0, braceIdx).trim();
+      break;
+    }
+    if (line.trim().endsWith(";")) break;
+  }
+  return sig.replace(/\s+/g, " ").trim();
+}
+
+const ITEM_RE =
+  /^pub\s+(?:async\s+)?(fn|struct|enum|trait|type|const)\s+(\w+)/;
+
+function parseFile(filePath) {
+  const content = readFileSync(filePath, "utf8");
+  const lines = content.split("\n");
+  const items = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    const m = line.match(ITEM_RE);
+    if (!m) continue;
+
+    const kind = m[1];
+    const name = m[2];
+    const doc = collectDocLines(lines, i);
+    const signature = extractSignature(lines, i);
+
+    items.push({ kind, name, doc, signature });
+  }
+
+  return items;
+}
+
+function processCrate({ name, srcPath, description }) {
+  const files = walkDir(srcPath);
+  const items = [];
+
+  for (const file of files) {
+    items.push(...parseFile(file));
+  }
+
+  // De-duplicate by name (same name can appear in multiple files via impl blocks)
+  const seen = new Set();
+  const unique = items.filter((item) => {
+    if (seen.has(item.name)) return false;
+    seen.add(item.name);
+    return true;
+  });
+
+  return { name, path: `crates/${name}`, description, items: unique };
+}
+
+function main() {
+  const crates = CRATES.map(processCrate);
+  const totalItems = crates.reduce((s, c) => s + c.items.length, 0);
+
+  const output = {
+    generated_at: new Date().toISOString(),
+    version: "1.0.0",
+    crates,
+  };
+
+  writeFileSync(OUT_FILE, JSON.stringify(output, null, 2), "utf8");
+  console.log(`api-data.json written to ${OUT_FILE}`);
+  console.log(`Extracted ${totalItems} public items from ${CRATES.length} crates`);
+}
+
+main();


### PR DESCRIPTION


closes #180
closes #182
closes #184
closes #196

## Summary

### #180 — Client-Side Search (Algolia DocSearch)

- Added `@docsearch/react` and `@docsearch/css` as dependencies (`package.json`).
- Created `frontend/components/DocSearch.tsx`: wraps the Algolia DocSearch component with dynamic import (SSR-safe). When `NEXT_PUBLIC_ALGOLIA_APP_ID` and `NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY` are not set the component renders a non-functional placeholder so the site builds without credentials.
- Replaced the non-functional search `<input>` in `Navbar.tsx` with the `DocSearch` component.
- Added DocSearch CSS import and full dark/light theme overrides to `globals.css` so the search modal matches the existing neutral/black palette.
- Added `frontend/.env.local.example` documenting the three required environment variables. Apply for a free index at https://docsearch.algolia.com/apply.

### #182 — Previous/Next Page Pagination

- Extracted the hardcoded `navigation` array from `Sidebar.tsx` into `frontend/lib/navigation.ts`, adding a `getFlatNavItems()` helper that returns all leaf pages in sequential order.
- Created `frontend/components/PrevNextNav.tsx`: reads the current URL via `usePathname`, computes the previous and next entries from the flat list, and renders labeled `← Previous` / `Next →` links with the page titles.
- Mounted `<PrevNextNav />` inside `DocsLayout.tsx` after `{children}` so every doc page gets automatic sequential navigation without any per-page code.
- Removed the two hardcoded `<section>` prev/next blocks from `cap0075/page.tsx` and `polynomial-operations/page.tsx` (now handled by the shared component).

### #184 — API Reference Auto-Generation

- Created `frontend/scripts/generate-api-docs.mjs`: walks `crates/zk-core/src` and `crates/zk-soroban/src`, extracts all `pub` items (fn, struct, enum, trait, type, const) and their triple-slash doc comments via regex, and writes `frontend/lib/api-data.json`.
- Added a `prebuild` npm script so the JSON is regenerated on every `npm run build`, and a standalone `generate-api-docs` script for on-demand use.
- Committed `frontend/lib/api-data.json` as the initial snapshot so the page renders immediately without running the script first.
- Created `frontend/app/docs/api-reference/page.tsx`: reads the JSON (via `resolveJsonModule`), renders each crate as a section of collapsible item cards with kind badges (fn, struct, enum, trait, const), full doc text, and the extracted signature. Includes generation timestamp and version metadata.

### #196 — Architecture Overview

- Created `frontend/app/docs/architecture/page.tsx` covering:
  - The Zero-Overhead philosophy (no heap allocation, no dynamic dispatch, host delegation).
  - Crate dependency diagram (`verifier-sample` → `zk-soroban` → `zk-core`), explaining why the `no_std` split keeps WASM under 64 KB.
  - A step-by-step breakdown of the `U256 → Fr` conversion path in `HostConvert::fr_from_u256`, including the `overflowing_sub` modulus check.
  - BN254 field parameters (`FR_MODULUS`, `FQ_MODULUS`) with annotated code and a comparison table of Fr vs Fq.
  - The three Soroban hard limits (64 KB WASM, 400 M instructions, 0 B heap in hot paths) that drove every design decision.
- Added "Architecture Overview" as the first entry in the Core Concepts section of `frontend/lib/navigation.ts`.
- Added "API Reference" as the first entry in the API Reference section of `frontend/lib/navigation.ts`.

## Notes for reviewers

- `npm install` is required after merging to pull `@docsearch/react` and `@docsearch/css`.
- Algolia DocSearch credentials are optional at build time. Without them the search bar is visible but non-interactive; no build error is thrown.
- `generate-api-docs.mjs` expects to be run from the `frontend/` directory and resolves crate paths relative to the repo root (`../../crates/`). It works on any OS.
