### PR TITLE
feat: Add G2 coordinate validation to BN254 pairing wrapper

### DIFF
--- a/crates/zk-core/src/lib.rs
+++ b/crates/zk-core/src/lib.rs
@@ -229,6 +229,16 @@ impl Bn254 {
     pub fn is_valid_scalar(val: u256) -> bool {
         val < Self::FR_MODULUS
     }
+
+    /// Validates a BN254 base field element in Fq.
+    ///
+    /// This ensures the element is within the field modulus and prevents
+    /// malformed G2 coordinate components from being passed into the native
+    /// host pairing call.
+    pub fn is_valid_fq(val: u256) -> bool {
+        val < Self::FQ_MODULUS
+    }
+
     pub fn add(a: u256, b: u256) -> u256 {
         Self::add_mod(a, b, Self::FR_MODULUS)
     }

--- a/crates/zk-soroban/src/pairing.rs
+++ b/crates/zk-soroban/src/pairing.rs
@@ -47,6 +47,15 @@ fn g1_to_bytes(g1: &G1Affine) -> [u8; 64] {
     bytes
 }
 
+fn validate_g2_coords(g2: &G2Affine) -> bool {
+    let (x0, x1) = g2.x;
+    let (y0, y1) = g2.y;
+    Bn254::is_valid_fq(x0)
+        && Bn254::is_valid_fq(x1)
+        && Bn254::is_valid_fq(y0)
+        && Bn254::is_valid_fq(y1)
+}
+
 /// Evaluates the BN254 pairing check e(A1, B1) * ... * e(An, Bn) == 1.
 pub fn pairing_check(env: &Env, pairs: &[(G1Affine, G2Affine)]) -> Result<bool, ZkError> {
     if pairs.is_empty() {
@@ -57,7 +66,7 @@ pub fn pairing_check(env: &Env, pairs: &[(G1Affine, G2Affine)]) -> Result<bool, 
     let mut vp2: Vec<SdkG2Affine> = Vec::new(env);
 
     for (g1, g2) in pairs {
-        if !Bn254::is_valid_g1_subgroup(g1.x, g1.y) {
+        if !Bn254::is_valid_g1_subgroup(g1.x, g1.y) || !validate_g2_coords(g2) {
             return Err(ZkError::InvalidInput);
         }
 
@@ -167,6 +176,20 @@ mod tests {
             y: u256::from(0u8),
         };
         let result = pairing_check(&env, &[(invalid_g1, g2_generator())]);
+        assert_eq!(result, Err(ZkError::InvalidInput));
+    }
+
+    #[test]
+    fn test_pairing_rejects_invalid_g2_components() {
+        let env = Env::default();
+        let mut invalid_g2 = g2_generator();
+        invalid_g2.x.0 = u256::from_str_radix(
+            "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47",
+            16,
+        )
+        .unwrap();
+
+        let result = pairing_check(&env, &[(g1_generator(), invalid_g2)]);
         assert_eq!(result, Err(ZkError::InvalidInput));
     }
 }


### PR DESCRIPTION
#Closes #109

---

#closes 109

- Add Bn254::is_valid_fq() method to validate Fq field elements
- Add validate_g2_coords() helper to check all G2 coordinates before host call
- Add test_pairing_rejects_invalid_g2_components regression test
- Prevents malformed G2 coordinates from being passed to native host pairing

## Description
## Linked Issue
Fixes #

## Mathematical/Cryptographic Impact
## PR Checklist
- [ ] I have run `make all` locally and everything passes.
- [ ] My code strictly adheres to `no_std` (no standard library imports).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have not introduced any `.unwrap()` or `panic!()` calls (using custom errors instead).
- [ ] My changes do not push the core WASM binary over the 64KB limit.

#closes