### PR TITLE
feat: implement one-click copy on all code snippets

### DIFF
--- a/frontend/app/docs/content/[slug]/page.tsx
+++ b/frontend/app/docs/content/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { DocsLayout } from '@/components/DocsLayout';
 import { Alert } from '@/components/mdx/Alert';
 import { Callout } from '@/components/mdx/Callout';
 import { Demo } from '@/components/mdx/Demo';
+import { MdxCodeBlock } from '@/components/mdx/MdxCodeBlock';
 import { getAllDocSlugs, getDocFilePath } from '@/lib/mdx';
 
 export async function generateStaticParams() {
@@ -65,15 +66,7 @@ const mdxComponents = {
   code: ({ children, className }: { children?: React.ReactNode; className?: string }) => {
     const isBlock = className?.startsWith('language-');
     if (isBlock) {
-      return (
-        <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-950 my-4 overflow-hidden">
-          <pre className="p-4 overflow-x-auto text-sm">
-            <code className={`${className} text-neutral-800 dark:text-neutral-200 font-mono`}>
-              {children}
-            </code>
-          </pre>
-        </div>
-      );
+      return <MdxCodeBlock className={className}>{children}</MdxCodeBlock>;
     }
     return (
       <code className="bg-neutral-100 dark:bg-neutral-800 text-black dark:text-white px-1.5 py-0.5 rounded text-sm font-mono">

--- a/frontend/components/CodeBlock.tsx
+++ b/frontend/components/CodeBlock.tsx
@@ -195,7 +195,7 @@ export function CodeBlock({
           className={`absolute top-3 right-3 z-10 p-1.5 rounded-md text-xs font-mono transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-black dark:focus:ring-white ${
             copied
               ? "bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400 opacity-100"
-              : "bg-neutral-200/80 dark:bg-neutral-800/80 text-neutral-500 dark:text-neutral-400 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:bg-neutral-300 dark:hover:bg-neutral-700"
+              : "bg-neutral-200/80 dark:bg-neutral-800/80 text-neutral-500 dark:text-neutral-400 hover:bg-neutral-300 dark:hover:bg-neutral-700"
           }`}
           aria-label={copied ? "Copied!" : "Copy code"}
         >

--- a/frontend/components/markdown/MarkdownRenderer.tsx
+++ b/frontend/components/markdown/MarkdownRenderer.tsx
@@ -1,10 +1,54 @@
 "use client";
 
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import 'katex/dist/katex.min.css';
+
+function BlockCode({ language, className, children, ...props }: { language: string; className: string; children: React.ReactNode; [key: string]: any }) {
+  const [copied, setCopied] = useState(false);
+  const codeRef = useRef<HTMLElement>(null);
+
+  const handleCopy = async () => {
+    const text = codeRef.current?.textContent?.trim() ?? "";
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {}
+  };
+
+  return (
+    <div className="rounded-md bg-zinc-950 border border-zinc-800 my-4 overflow-hidden">
+      <div className="bg-zinc-900 px-4 py-2 text-xs text-zinc-500 border-b border-zinc-800 flex justify-between items-center">
+        <span>{language}</span>
+        <button
+          onClick={handleCopy}
+          className={`p-1.5 rounded-md transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white ${
+            copied ? "text-green-400" : "text-zinc-500 hover:text-zinc-200"
+          }`}
+          aria-label={copied ? "Copied!" : "Copy code"}
+        >
+          {copied ? (
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+            </svg>
+          ) : (
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+            </svg>
+          )}
+        </button>
+      </div>
+      <pre className="p-4 overflow-x-auto">
+        <code ref={codeRef} className={className} {...props}>
+          {children}
+        </code>
+      </pre>
+    </div>
+  );
+}
 
 interface MarkdownRendererProps {
   content: string;
@@ -29,16 +73,9 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, cla
           code: ({node, inline, className, children, ...props}: any) => {
             const match = /language-(\w+)/.exec(className || '');
             return !inline && match ? (
-              <div className="rounded-md bg-zinc-950 border border-zinc-800 my-4 overflow-hidden">
-                <div className="bg-zinc-900 px-4 py-2 text-xs text-zinc-500 border-b border-zinc-800 flex justify-between items-center">
-                  <span>{match[1]}</span>
-                </div>
-                <pre className="p-4 overflow-x-auto">
-                  <code className={className} {...props}>
-                    {children}
-                  </code>
-                </pre>
-              </div>
+              <BlockCode language={match[1]} className={className} {...props}>
+                {children}
+              </BlockCode>
             ) : (
               <code className="bg-zinc-800 text-zinc-200 px-1.5 py-0.5 rounded text-sm" {...props}>
                 {children}

--- a/frontend/components/mdx/MdxCodeBlock.tsx
+++ b/frontend/components/mdx/MdxCodeBlock.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import React, { useRef, useState } from "react";
+
+interface MdxCodeBlockProps {
+  children?: React.ReactNode;
+  className?: string;
+}
+
+export function MdxCodeBlock({ children, className }: MdxCodeBlockProps) {
+  const [copied, setCopied] = useState(false);
+  const codeRef = useRef<HTMLElement>(null);
+  const lang = /language-(\w+)/.exec(className ?? "")?.[1];
+
+  const handleCopy = async () => {
+    const text = codeRef.current?.textContent?.trim() ?? "";
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {}
+  };
+
+  return (
+    <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-950 my-4 overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-2 bg-neutral-100 dark:bg-neutral-900 border-b border-neutral-200 dark:border-neutral-800">
+        <span className="text-xs font-mono text-neutral-500 dark:text-neutral-400">
+          {lang ?? "code"}
+        </span>
+        <button
+          onClick={handleCopy}
+          className={`p-1.5 rounded-md transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-black dark:focus:ring-white ${
+            copied
+              ? "text-green-600 dark:text-green-400"
+              : "text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200"
+          }`}
+          aria-label={copied ? "Copied!" : "Copy code"}
+        >
+          {copied ? (
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+            </svg>
+          ) : (
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+            </svg>
+          )}
+        </button>
+      </div>
+      <pre className="p-4 overflow-x-auto text-sm">
+        <code
+          ref={codeRef}
+          className={`${className ?? ""} text-neutral-800 dark:text-neutral-200 font-mono`}
+        >
+          {children}
+        </code>
+      </pre>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Added always-visible copy button to `CodeBlock.tsx` (was previously hidden until hover)
- Created new `MdxCodeBlock` client component with copy button for MDX-rendered fenced code blocks
- Added `BlockCode` sub-component to `MarkdownRenderer.tsx` with copy button matching the zinc dark theme
- Wired `MdxCodeBlock` into the MDX content page (`/docs/content/[slug]`) replacing the bare `<pre><code>` block

## Behaviour

- Clicking the copy icon copies the raw code text to clipboard via `navigator.clipboard`
- Button shows a green checkmark for 2 seconds on success, then resets
- Copy button is always visible (no hover required) across all three rendering paths
- Inline `<code>` spans are unaffected

## Test plan

- [ ] Visit `/docs` — copy button visible on all `CodeBlock` snippets without hovering
- [ ] Visit a `/docs/content/[slug]` MDX page — copy button appears in the header of every fenced code block
- [ ] Visit any page using `MarkdownRenderer` — copy button appears in block code, not on inline code
- [ ] Click copy and paste into an editor — confirm exact code text is copied with no extra whitespace
- [ ] Confirm the green checkmark appears and resets after ~2 seconds

Closes #178
