### PR TITLE
fixes issue 212

### DIFF
--- a/docs/zk-cryptography-glossary.md
+++ b/docs/zk-cryptography-glossary.md
@@ -90,6 +90,30 @@ KZG commitments are:
 
 > **Analogy:** Like sealing a recipe in an envelope. Later, you can open a tiny window to show just one ingredient, and the seal proves you didn't change the recipe.
 
+---
+
+## SRS — Structured Reference String
+
+A **Structured Reference String (SRS)** is a set of public parameters created by a trusted setup ceremony for pairing-based proof systems such as PLONK and KZG.
+
+The SRS itself is not secret after generation, but it must be managed as an immutable, integrity-protected artifact.
+
+- Load the SRS from a trusted source, such as a verified deployment artifact, signed release, or host-managed parameter store.
+- Validate the SRS before using it, for example by comparing a checksum or signature against a known good value.
+- Avoid runtime loading from arbitrary external URLs or unverified storage.
+- If the contract needs to store the SRS on-chain, initialize it once through a guarded setup step and then keep it immutable.
+- Reuse a single SRS across compatible verifier contracts to reduce the risk of mismatched or tampered parameters.
+
+In a Soroban environment, the recommended pattern is to treat the SRS like public protocol parameters:
+
+1. Generate the SRS off-chain for the target curve and maximum circuit size.
+2. Package it with the contract or supply it through a trusted deployment pipeline.
+3. Verify integrity before deployment and again at initialization if the contract loads it from storage.
+4. Reference the SRS from verified contract logic rather than fetching it from an untrusted runtime source.
+
+> **Why this matters:** A bad or malicious SRS can make proofs invalid or allow attackers to cheat, so the integrity of the SRS is just as important as the secrecy of the proving witness.
+
+---
 
 ## M — Merkle Tree
 


### PR DESCRIPTION
Description

Added a dedicated SRS (Structured Reference String) section to the cryptography glossary.
Explains how to securely load, validate, and manage SRS parameters in Soroban contracts.
Covers trusted source loading, integrity validation, on-chain immutability, and best practices for reuse across contracts.

Linked Issue
Fixes: #212 

Mathematical/Cryptographic Impact

Scope: Documentation-only. No algorithms, proofs, or cryptographic changes.
Impact: Provides security guidance on SRS handling to prevent misuse of setup parameters. No runtime behavior modified.

PR Checklist

 I have run make all locally and everything passes. (Documentation-only; no build artifacts affected.)
 My code strictly adheres to no_std (docs-only change).
 I have added tests that prove my fix is effective or that my feature works. (Not applicable for documentation.)
 I have not introduced any .unwrap() or panic!() calls (docs-only change).
 My changes do not push the core WASM binary over the 64KB limit (docs-only change).