### PR TITLE
docs: Convert documentation to MDX format with frontmatter standards  Closes #[issue-number] (if applicable)

### DIFF
--- a/docs/ASP_Integration.mdx
+++ b/docs/ASP_Integration.mdx
@@ -1,0 +1,41 @@
+---
+title: "Association Set Providers (ASP) Integration on Stellar"
+description: "Privacy pools and association set providers for compliant privacy-preserving transactions on Stellar"
+protocol: "25"
+cap: "CAP-0075"
+---
+
+# Association Set Providers (ASP) Integration on Stellar
+
+Privacy on public ledgers often introduces a conflict between individual financial confidentiality and regulatory compliance. The concept of **Privacy Pools** and **Association Set Providers (ASPs)** resolves this by allowing users to prove that their funds do not originate from illicit sources without revealing their exact transaction history.
+
+## What is an Association Set Provider?
+
+An ASP is an off-chain entity or smart contract that maintains a dynamic list (an "association set") of compliant or non-compliant actors. 
+Instead of revealing their identity, users generate Zero-Knowledge Proofs (ZKPs) demonstrating that their transaction history is part of a "compliant" set (or definitively *not* part of a "sanctioned" set).
+
+## How ASPs Work with Shielded Assets
+
+The `shielded-asset-template` contract in `Soroban-ZK-Std` allows the integration of ASPs through the following mechanism:
+
+### 1. Merkle Trees for State Management
+The ASP maintains a Merkle Tree representing the current set of known compliant deposits. The Merkle Root is periodically published to the Soroban smart contract.
+
+### 2. Zero-Knowledge Proof Generation
+When a user wishes to transfer a shielded asset, they generate a Groth16 (or Plonk) proof off-chain. This proof cryptographically asserts:
+*   "I know the private key for a deposit inside the Merkle Tree with root `R`."
+*   "I have not spent this deposit before (via a revealed Nullifier)."
+*   "The value I am transferring does not exceed my deposit."
+
+### 3. Viewing Keys for Regulatory Compliance
+While the ZKP proves the transaction is valid and compliant, the *amount* transferred remains hidden from the public. To satisfy audit requirements, the `shielded-asset-template` uses an **ElGamal Ciphertext** viewing key system over the BN254 elliptic curve.
+*   The transaction amount is encrypted using a regulatory body's Public Key.
+*   The regulator (holding the private key) can intercept the Soroban transaction, perform a point decryption, and recover the exact amount transferred.
+*   The public observer sees only cryptographic noise (the ElGamal `C1` and `C2` points).
+
+## Stellar Integration Flow
+
+1. **Deposit**: A user deposits standard Stellar assets (e.g., USDC) into the privacy pool. The ASP includes their deposit commitment in the Merkle Tree.
+2. **Transfer**: The user generates a ZK proof of membership against the ASP's Merkle Root and encrypts the transfer amount using the ElGamal viewing key.
+3. **Verification**: The Soroban smart contract uses `Soroban-ZK-Std` to verify the Groth16 proof and validate the ElGamal ciphertext points.
+4. **Audit**: Regulators utilize their private viewing keys to decrypt transaction amounts when required by law, ensuring full transparency without compromising public privacy.

--- a/docs/cap0075-integration-guide.mdx
+++ b/docs/cap0075-integration-guide.mdx
@@ -1,0 +1,266 @@
+---
+title: "CAP-0075 Integration Guide"
+description: "How Soroban-ZK-Std wraps native Stellar pairing host functions for zero-knowledge proof verification"
+protocol: "25"
+cap: "CAP-0075"
+---
+
+# CAP-0075 Integration Guide
+
+> **How Soroban-ZK-Std wraps native Stellar pairing host functions for zero-knowledge proof verification.**
+
+## Overview
+
+[CAP-0075](https://stellar.org/protocol/cap-0075) (introduced alongside CAP-0074 in Protocol 25 "X-Ray") brings native host functions for BN254 pairing checks and Poseidon2 hashing directly into the Soroban Virtual Machine. This eliminates the need for expensive software-only implementations of these primitives, reducing gas costs by orders of magnitude.
+
+**Soroban-ZK-Std** provides a safe, ergonomic Rust abstraction layer over these raw host functions, handling:
+
+- Correct byte serialization for G1/G2 points (per CAP-0074 §3.2)
+- Type-safe wrappers that prevent misuse
+- Fallible APIs that return `Result<T, ZkError>` instead of panicking
+
+## Background: BN254 Pairing
+
+The BN254 curve (also known as alt_bn128) supports **bilinear pairings** — a special function `e(P, Q)` that maps pairs of elliptic curve points to elements of a target group. The key property is **bilinearity**:
+
+```
+e(aP, bQ) = e(P, Q)^(ab)
+```
+
+This property is the foundation of Groth16 and other pairing-based zero-knowledge proof systems. A ZK verifier checks that certain pairing equations hold, which proves computational statements without revealing inputs.
+
+### The Multi-Pairing Check
+
+Stellar's host function `bn254_multi_pairing_check` evaluates:
+
+```
+e(A₁, B₁) · e(A₂, B₂) · ... · e(Aₙ, Bₙ) = 1
+```
+
+This is the exact check needed by Groth16 verifiers. The host function performs this as a **single atomic operation**, which is vastly more efficient than computing individual pairings and multiplying.
+
+## Library Architecture
+
+### Core Types
+
+#### `G1Affine` (from `zk-core`)
+A BN254 G1 point in affine coordinates:
+
+```rust
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct G1Affine {
+    pub x: u256,  // x-coordinate in Fq
+    pub y: u256,  // y-coordinate in Fq
+}
+```
+
+#### `G2Affine` (from `zk-soroban::pairing`)
+A BN254 G2 point in affine coordinates. G2 lives in the degree-2 extension field Fq², so each coordinate is a pair `(c0, c1)` representing `c0 + c1·u`:
+
+```rust
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct G2Affine {
+    pub x: (u256, u256),  // (real, imaginary) in Fq²
+    pub y: (u256, u256),  // (real, imaginary) in Fq²
+}
+```
+
+### Serialization
+
+#### G1 Serialization (64 bytes)
+```
+Bytes  0..32:  x (Big-Endian)
+Bytes 32..64:  y (Big-Endian)
+```
+
+#### G2 Serialization (128 bytes, per CAP-0074 §3.2)
+```
+Bytes   0..32:   x.1 (X imaginary / c1, Big-Endian)
+Bytes  32..64:   x.0 (X real / c0, Big-Endian)
+Bytes  64..96:   y.1 (Y imaginary / c1, Big-Endian)
+Bytes  96..128:  y.0 (Y real / c0, Big-Endian)
+```
+
+> **Important:** The byte ordering places the *imaginary* component before the *real* component. This follows the CAP-0074 specification and differs from some other libraries.
+
+### The `pairing_check` Function
+
+The main entry point for pairing verification:
+
+```rust
+use zk_soroban::pairing::{pairing_check, G2Affine};
+use zk_core::G1Affine;
+
+/// Evaluates the BN254 pairing check:
+/// e(A₁, B₁) · e(A₂, B₂) · ... · e(Aₙ, Bₙ) == 1
+pub fn pairing_check(
+    env: &Env,
+    pairs: &[(G1Affine, G2Affine)]
+) -> Result<bool, ZkError>
+```
+
+**Parameters:**
+- `env` — The Soroban host environment
+- `pairs` — A slice of `(G1, G2)` point pairs
+
+**Returns:**
+- `Ok(true)` if the multi-pairing product equals the identity
+- `Ok(false)` if the check fails
+- `Err(ZkError::InvalidInput)` if the pairs slice is empty
+
+**Internally, this function:**
+1. Iterates over each `(G1, G2)` pair
+2. Serializes each point to its byte representation
+3. Constructs Soroban SDK types (`Bn254G1Affine`, `Bn254G2Affine`) via `from_bytes()`
+4. Calls `env.crypto().bn254().pairing_check(vp1, vp2)` — the native host function
+
+## Step-by-Step: Building a Groth16 Verifier
+
+### 1. Define Your Verification Key
+
+A Groth16 verification key consists of several G1 and G2 points. These are generated during the trusted setup phase:
+
+```rust
+use ethnum::u256;
+use zk_core::G1Affine;
+use zk_soroban::pairing::G2Affine;
+
+// These would come from your trusted setup ceremony
+struct VerificationKey {
+    alpha_g1: G1Affine,
+    beta_g2: G2Affine,
+    gamma_g2: G2Affine,
+    delta_g2: G2Affine,
+    ic: [G1Affine; 2],  // Input commitments
+}
+```
+
+### 2. Verify a Proof
+
+```rust
+use soroban_sdk::Env;
+use zk_soroban::pairing::pairing_check;
+
+struct Proof {
+    a: G1Affine,
+    b: G2Affine,
+    c: G1Affine,
+}
+
+fn verify_groth16(
+    env: &Env,
+    vk: &VerificationKey,
+    proof: &Proof,
+    public_inputs: &[G1Affine],
+) -> Result<bool, ZkError> {
+    // Compute the linear combination of public inputs
+    // vk_x = IC[0] + sum(public_input[i] * IC[i+1])
+    // (simplified — real implementation uses scalar_mul)
+
+    // The Groth16 verification equation:
+    // e(A, B) · e(-vk_x, gamma) · e(-C, delta) · e(-alpha, beta) == 1
+    let pairs = [
+        (proof.a, proof.b),
+        (negate_g1(vk.ic[0]), vk.gamma_g2),
+        (negate_g1(proof.c), vk.delta_g2),
+        (negate_g1(vk.alpha_g1), vk.beta_g2),
+    ];
+
+    pairing_check(env, &pairs)
+}
+```
+
+### 3. Identity Check Example
+
+The simplest pairing test: verify that `e(G1, G2) · e(-G1, G2) == 1`:
+
+```rust
+#[test]
+fn test_pairing_identity() {
+    let env = Env::default();
+
+    let g1 = G1Affine {
+        x: u256::from(1u8),
+        y: u256::from(2u8),
+    };
+
+    // Negate G1: (x, p - y) where p is the field modulus
+    let g1_neg = G1Affine {
+        x: u256::from(1u8),
+        y: u256::from_str_radix(
+            "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd45",
+            16,
+        ).unwrap(),
+    };
+
+    let g2 = g2_generator(); // Standard BN254 G2 generator
+
+    let result = pairing_check(&env, &[(g1, g2), (g1_neg, g2)]);
+    assert!(result.unwrap()); // e(G1, G2) · e(-G1, G2) == 1
+}
+```
+
+## Poseidon2 Integration
+
+CAP-0075 also provides a native `poseidon2_permutation` host function, exposed through:
+
+```rust
+use zk_soroban::poseidon2;
+```
+
+Poseidon2 is a ZK-friendly hash function optimized for arithmetic circuits. The native host function is **47% faster** than a software implementation, and the library's wrapper handles:
+
+- Correct state initialization
+- Domain separation
+- Input padding
+- Output extraction
+
+### Usage
+
+```rust
+use zk_soroban::poseidon2::Poseidon2;
+use soroban_sdk::Env;
+
+fn hash_inputs(env: &Env, left: u256, right: u256) -> u256 {
+    // Uses the native poseidon2_permutation host function
+    Poseidon2::hash_two(env, left, right)
+}
+```
+
+## Performance Comparison
+
+| Operation | Software-Only | With CAP-0075 Host Functions | Speedup |
+|-----------|--------------|-------------------------------|---------|
+| BN254 Pairing Check (2 pairs) | ~380M instructions | ~2M instructions | **190×** |
+| Poseidon2 Hash | ~1.2M instructions | ~640K instructions | **1.9×** |
+| Groth16 Verify (4 pairs) | Exceeds 400M budget | ~4M instructions | **∞** (was impossible) |
+
+> **Key insight:** Without CAP-0075 host functions, a Groth16 verifier *cannot run* within Soroban's 400M instruction budget. The native host functions make ZK verification on Stellar practical for the first time.
+
+## Scalar Field Conversion
+
+In addition to pairing, `zk-soroban` provides the `HostConvert` trait for safe conversion between Soroban's `U256` and BN254's scalar field `Fr`:
+
+```rust
+use zk_soroban::HostConvert;
+use soroban_sdk::{Env, U256};
+
+fn convert_scalar(env: &Env, val: U256) -> Result<Fr, ZkError> {
+    // Zero-copy stack allocation: reads Soroban U256 as big-endian
+    // bytes and validates it's within [0, r)
+    env.fr_from_u256(val)
+}
+```
+
+This ensures that all field elements entering the ZK system are properly validated, preventing out-of-bounds errors that could compromise proof soundness.
+
+## Summary
+
+The `zk-soroban` crate bridges the gap between Stellar's raw CAP-0075 host functions and the developer experience needed to build production ZK applications:
+
+1. **`pairing_check()`** wraps `env.crypto().bn254().pairing_check()` with proper type safety and serialization
+2. **`G2Affine`** handles the non-trivial Fq² serialization per CAP-0074 §3.2
+3. **`HostConvert`** trait provides safe `U256 → Fr` conversion
+4. **`Poseidon2`** exposes the native hash function with ergonomic APIs
+
+Together, these make Stellar the premier platform for configurable, compliance-forward privacy on a public blockchain.

--- a/docs/getting-started-guide.mdx
+++ b/docs/getting-started-guide.mdx
@@ -1,0 +1,313 @@
+---
+title: "Getting Started Guide"
+description: "Step-by-step instructions for integrating Soroban-ZK-Std into a new Soroban smart contract"
+protocol: "25"
+cap: "CAP-0075"
+---
+
+# Getting Started Guide
+
+> **Step-by-step instructions for integrating Soroban-ZK-Std into a new Soroban smart contract.**
+
+## Overview
+
+This guide walks you through adding zero-knowledge proof capabilities to your Soroban contract using the `Soroban-ZK-Std` library. By the end, you will have a working contract that can verify Groth16 proofs, hash with Poseidon2, and perform BN254 pairing checks — all within Soroban's WASM and instruction budget limits.
+
+---
+
+## Prerequisites
+
+Before starting, ensure you have the following installed:
+
+| Tool | Version | Installation Command |
+|------|---------|---------------------|
+| **Rust** | nightly (recommended) or stable | `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \| sh` |
+| **WebAssembly target** | — | `rustup target add wasm32-unknown-unknown` |
+| **Soroban CLI** | latest | `cargo install --locked soroban-cli` |
+| **Make** | system | `apt install build-essential` (Linux) or `xcode-select --install` (macOS) |
+
+> **Verify your installation:**
+> ```bash
+> rustc --version
+> cargo --version
+> soroban --version
+> ```
+
+---
+
+## Step 1: Create a New Soroban Contract
+
+If you don't already have a contract, create one using the Soroban CLI:
+
+```bash
+soroban contract init my-zk-contract
+cd my-zk-contract
+```
+
+This generates a basic Soroban contract scaffold with a `Cargo.toml`, `src/lib.rs`, and a test file.
+
+---
+
+## Step 2: Add Soroban-ZK-Std as a Dependency
+
+Edit your `Cargo.toml` to add the `zk-soroban` crate:
+
+```toml
+[dependencies]
+soroban-sdk = "25.0.0"
+zk-soroban = { git = "https://github.com/georgegoldman/Soroban-ZK-Std" }
+
+# You may also need these for field arithmetic:
+ethnum = "1.3"
+```
+
+> **Note:** The exact Soroban SDK version should match the protocol version your contract targets. Check the [Soroban documentation](https://developers.stellar.org/docs/soroban) for the latest compatibility matrix.
+
+
+## Step 3: Import the Library in Your Contract
+
+In your `src/lib.rs`, import the types and functions you need:
+
+```rust
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Vec};
+use zk_core::{G1Affine, Bn254};
+use zk_soroban::pairing::{G2Affine, pairing_check};
+use zk_soroban::poseidon2::Poseidon2;
+use zk_soroban::ZkError;
+```
+
+---
+
+## Step 4: Use Pairing Checks (Groth16 Verification)
+
+Here is a minimal contract that exposes a Groth16 proof verification endpoint:
+
+```rust
+#[contract]
+pub struct ZKVerifier;
+
+#[contractimpl]
+impl ZKVerifier {
+    /// Verifies a Groth16 proof given the verification key and public inputs.
+    ///
+    /// # Parameters
+    /// - `proof_a`, `proof_b`, `proof_c`: The three proof points
+    /// - `vk_alpha_g1`, `vk_beta_g2`, `vk_gamma_g2`, `vk_delta_g2`: Verification key points
+    /// - `public_inputs`: Serialized public inputs
+    ///
+    /// # Returns
+    /// `true` if the proof is valid, `false` otherwise.
+    pub fn verify(
+        env: Env,
+        proof_a_bytes: Vec<u8>,
+        proof_b_bytes: Vec<u8>,
+        proof_c_bytes: Vec<u8>,
+        vk_alpha_g1_bytes: Vec<u8>,
+        vk_beta_g2_bytes: Vec<u8>,
+        vk_gamma_g2_bytes: Vec<u8>,
+        vk_delta_g2_bytes: Vec<u8>,
+        public_inputs: Vec<u8>,
+    ) -> bool {
+        // Deserialize points from bytes
+        // Note: In a real contract, you would implement from_bytes
+        // for each type. See the zk-soroban crate for helpers.
+
+        // Build the pairing check pairs
+        let pairs = [
+            (
+                deserialize_g1(&proof_a_bytes),
+                deserialize_g2(&proof_b_bytes),
+            ),
+            (
+                negate_g1(deserialize_g1(&public_inputs)),
+                deserialize_g2(&vk_gamma_g2_bytes),
+            ),
+            (
+                negate_g1(deserialize_g1(&proof_c_bytes)),
+                deserialize_g2(&vk_delta_g2_bytes),
+            ),
+            (
+                negate_g1(deserialize_g1(&vk_alpha_g1_bytes)),
+                deserialize_g2(&vk_beta_g2_bytes),
+            ),
+        ];
+
+        pairing_check(&env, &pairs).unwrap_or(false)
+    }
+}
+```
+
+> **Key insight:** The pairing check evaluates `e(A₁, B₁) · e(A₂, B₂) · ... · e(Aₙ, Bₙ) == 1`. Negating certain G1 points achieves the standard Groth16 verification equation.
+
+
+## Step 5: Use Poseidon2 Hashing
+
+To hash values in your contract using the native Poseidon2 host function:
+
+```rust
+#[contractimpl]
+impl ZKVerifier {
+    /// Hashes two field elements using Poseidon2.
+    pub fn hash_two_values(env: Env, left: u256, right: u256) -> u256 {
+        Poseidon2::hash_two(&env, left, right)
+    }
+
+    /// Computes a Merkle root from leaves using Poseidon2 as the hash function.
+    pub fn compute_merkle_root(env: Env, leaves: Vec<u256>) -> u256 {
+        // Build the Merkle tree bottom-up using Poseidon2 hashing
+        let mut current_level: Vec<u256> = leaves;
+
+        while current_level.len() > 1 {
+            let mut next_level: Vec<u256> = Vec::new(&env);
+            for chunk in current_level.chunks(2) {
+                let left = chunk[0];
+                let right = if chunk.len() > 1 { chunk[1] } else { left };
+                let hash = Poseidon2::hash_two(&env, left, right);
+                next_level.push_back(hash);
+            }
+            current_level = next_level;
+        }
+
+        current_level.get(0).unwrap_or(u256::from(0u8))
+    }
+}
+```
+
+---
+
+## Step 6: Build and Test
+
+### Build the WASM Contract
+
+```bash
+cargo build --target wasm32-unknown-unknown --release
+```
+
+### Check WASM Size
+
+```bash
+twiggy top target/wasm32-unknown-unknown/release/my_zk_contract.wasm
+```
+
+Your contract should be well under Soroban's **64KB** limit. If it exceeds this, check for accidental `std` dependencies.
+
+### Run Tests
+
+```bash
+cargo test
+```
+
+
+## Step 7: Deploy and Invoke
+
+### Deploy to a Local Test Network
+
+```bash
+soroban contract deploy \
+    --wasm target/wasm32-unknown-unknown/release/my_zk_contract.wasm \
+    --source <your-identity> \
+    --network local
+```
+
+### Invoke the Contract
+
+```bash
+soroban contract invoke \
+    --id <contract-id> \
+    --source <your-identity> \
+    --network local \
+    -- \
+    verify \
+    --proof_a_bytes <hex-encoded-proof-a> \
+    --proof_b_bytes <hex-encoded-proof-b> \
+    --proof_c_bytes <hex-encoded-proof-c> \
+    --vk_alpha_g1_bytes <hex-encoded-vk-alpha> \
+    --vk_beta_g2_bytes <hex-encoded-vk-beta> \
+    --vk_gamma_g2_bytes <hex-encoded-vk-gamma> \
+    --vk_delta_g2_bytes <hex-encoded-vk-delta> \
+    --public_inputs <hex-encoded-public-inputs>
+```
+
+---
+
+## Complete Example Contract
+
+Here is a complete, minimal contract that uses Soroban-ZK-Std:
+
+```rust
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+use ethnum::u256;
+use zk_core::G1Affine;
+use zk_soroban::pairing::{G2Affine, pairing_check};
+use zk_soroban::poseidon2::Poseidon2;
+use zk_soroban::ZkError;
+
+#[contract]
+pub struct MinimalZK;
+
+#[contractimpl]
+impl MinimalZK {
+    /// Returns the Poseidon2 hash of two u256 values.
+    pub fn hash(env: Env, a: u256, b: u256) -> u256 {
+        Poseidon2::hash_two(&env, a, b)
+    }
+
+    /// Returns the result of a BN254 pairing check `e(G1, G2)`.
+    /// This is a minimal sanity check for contract integration testing.
+    pub fn check_pairing(env: Env) -> bool {
+        let g1 = G1Affine {
+            x: u256::from(1u8),
+            y: u256::from(2u8),
+        };
+        let g2 = G2Affine {
+            x: (
+                u256::from_str_radix("1800deef121f1e764ff97665de1f4e53e2d8f75cfb208be8a76c26f20b32c0b9", 16).unwrap(),
+                u256::from_str_radix("1800deef121f1e764ff97665de1f4e53e2d8f75cfb208be8a76c26f20b32c0b9", 16).unwrap(),
+            ),
+            y: (
+                u256::from_str_radix("198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2", 16).unwrap(),
+                u256::from_str_radix("1800deef121f1e764ff97665de1f4e53e2d8f75cfb208be8a76c26f20b32c0b9", 16).unwrap(),
+            ),
+        };
+        let pairs = [(g1, g2)];
+        pairing_check(&env, &pairs).unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::Env;
+
+    #[test]
+    fn test_hash() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, MinimalZK);
+        let client = MinimalZKClient::new(&env, &contract_id);
+        let result = client.hash(&u256::from(1u8), &u256::from(2u8));
+        assert!(result != u256::from(0u8));
+    }
+}
+```
+
+---
+
+## Troubleshooting
+
+| Problem | Likely Cause | Solution |
+|---------|-------------|----------|
+| **WASM binary too large (>64KB)** | Accidental `std` dependency | Ensure all dependencies are `no_std`-compatible. Check with `cargo tree` for `std` features. |
+| **Instruction budget exceeded** | Too many pairing pairs | Keep the number of `(G1, G2)` pairs in a single `pairing_check` call under 10 for typical budgets. |
+| **Compilation error: `use of undeclared crate or module`** | Missing dependency | Double-check your `Cargo.toml` includes `zk-soroban` and `zk-core`. |
+| **`pairing_check` returns `InvalidInput`** | Empty pairs slice | Ensure your pairs array has at least one `(G1, G2)` tuple. |
+
+---
+
+## Next Steps
+
+- **Explore the [API Reference](./cap0075-integration-guide.mdx)** for advanced usage of pairing checks, Poseidon2, and scalar field conversion.
+- **Learn about [Polynomial Operations](./polynomial-operations.mdx)** for building custom ZK circuits.
+- **Review the [ASP Integration Guide](./ASP_Integration.mdx)** to understand how to configure compliance workflows with Association Set Providers.
+- **Check the [Shielded Asset Template](../contracts/shielded-asset-template/)** for a complete private token implementation.

--- a/docs/math/cyclotomic.mdx
+++ b/docs/math/cyclotomic.mdx
@@ -1,0 +1,270 @@
+---
+title: "Cyclotomic Squaring in $\\mathbb{F}_{q^{12}}$"
+description: "Optimization strategy for final exponentiation in pairing-based cryptography"
+protocol: "25"
+cap: "CAP-0075"
+---
+
+# Cyclotomic Squaring in $\mathbb{F}_{q^{12}}$
+
+<div align="center">
+
+## Optimization Strategy for Final Exponentiation in Pairing-Based Cryptography
+
+**Soroban-ZK-Std**
+
+</div>
+
+---
+
+# 1. Introduction
+
+Pairing-based cryptographic systems over BN254 require arithmetic in the extension field:
+
+$$\mathbb{F}_{q^{12}}$$
+
+where $q$ is the BN254 base field modulus.
+
+One of the most computationally expensive stages of pairing evaluation is the **final exponentiation** step. Fortunately, this exponentiation contains algebraic structure that allows significant optimization.
+
+A key optimization is the use of **cyclotomic squaring**, which exploits the fact that intermediate pairing outputs lie inside a special subgroup of:
+
+$$\mathbb{F}_{q^{12}}^\times$$
+
+known as the **cyclotomic subgroup**.
+
+This document describes the mathematical structure underlying cyclotomic squaring and explains why it is substantially more efficient than generic extension-field squaring.
+
+---
+
+# 2. Final Exponentiation Overview
+
+For a pairing:
+
+$$e(P, Q)$$
+
+the Miller loop produces an intermediate value:
+
+$$f \in \mathbb{F}_{q^{12}}$$
+
+which must then be exponentiated by:
+
+$$\frac{q^{12} - 1}{r}$$
+
+where:
+
+* $q$ is the field modulus,
+* $r$ is the subgroup order.
+
+Thus:
+
+$$f^{\frac{q^{12}-1}{r}}$$
+
+produces the final pairing output.
+
+---
+
+# 3. Easy Part and Hard Part
+
+The final exponentiation is traditionally divided into two components.
+
+## Easy Part
+
+The easy component uses Frobenius maps and inversion:
+
+$$f^{(q^6 - 1)(q^2 + 1)}$$
+
+This step is computationally inexpensive because Frobenius maps in extension fields are nearly free.
+
+---
+
+## Hard Part
+
+The remaining exponentiation:
+
+$$f^{\frac{q^4 - q^2 + 1}{r}}$$
+
+is significantly more expensive.
+
+The result of the easy part lies inside the cyclotomic subgroup, enabling specialized arithmetic optimizations.
+
+---
+
+# 4. Cyclotomic Subgroup
+
+The cyclotomic subgroup is the subgroup:
+
+$$\mu_{q^4-q^2+1} \subseteq \mathbb{F}_{q^{12}}^\times$$
+
+whose elements satisfy additional algebraic structure.
+
+Elements in this subgroup admit compressed representations and faster squaring formulas.
+
+This property is essential because the hard part of final exponentiation consists largely of repeated squaring operations.
+
+---
+
+# 5. Standard Extension-Field Squaring
+
+A generic element of $\mathbb{F}_{q^{12}}$ can be written as:
+
+$$x = \sum_{i=0}^{11} a_i w^i$$
+
+where:
+
+* $a_i \in \mathbb{F}_q$,
+* $w$ is an extension generator.
+
+Naive squaring requires a large number of:
+
+* base-field multiplications,
+* cross terms,
+* modular reductions.
+
+This becomes expensive inside constrained proving systems and WASM execution environments.
+
+---
+
+# 6. Cyclotomic Representation
+
+Inside the cyclotomic subgroup, elements admit structured decomposition.
+
+Using the tower-field construction:
+
+$$\mathbb{F}_{q^{12}} = \mathbb{F}_{q^6}[v]/(v^2 - \xi)$$
+
+with:
+
+$$\mathbb{F}_{q^6} = \mathbb{F}_{q^2}[u]/(u^3 - \eta)$$
+
+cyclotomic subgroup elements can be represented using six effective coefficients instead of twelve independent coefficients.
+
+This structural symmetry enables optimized squaring identities.
+
+---
+
+# 7. Cyclotomic Squaring
+
+Let:
+
+$$x \in \mu_{q^4-q^2+1}$$
+
+Then cyclotomic squaring computes $x^2$ using specialized formulas that exploit subgroup symmetries.
+
+Instead of performing generic extension-field multiplication, the operation reduces to a smaller collection of:
+
+* sparse multiplications,
+* coefficient permutations,
+* additions and subtractions,
+* Frobenius-compatible transformations.
+
+---
+
+# 8. Algebraic Optimization
+
+Cyclotomic subgroup elements satisfy conjugacy relations that eliminate redundant computations.
+
+For suitable coefficient decomposition:
+
+$$x = (c_0, c_1, c_2, c_3, c_4, c_5)$$
+
+the square can be computed using identities of the form:
+
+$$(c_i + c_j)^2$$
+
+instead of independent full multiplications.
+
+This substantially lowers multiplication complexity.
+
+The optimization relies on:
+
+* coefficient symmetry,
+* subgroup closure,
+* sparse cross terms,
+* reduced dependency count.
+
+---
+
+# 9. Relationship to Frobenius Maps
+
+Cyclotomic subgroup arithmetic interacts efficiently with Frobenius endomorphisms.
+
+Because Frobenius actions correspond primarily to:
+
+* coefficient permutation,
+* multiplication by precomputed constants,
+
+many exponentiation stages become extremely inexpensive.
+
+This is especially important for BN254 final exponentiation, where repeated Frobenius applications dominate the easy part.
+
+---
+
+# 10. Why Cyclotomic Squaring Is Faster
+
+Compared to generic $\mathbb{F}_{q^{12}}$ squaring, cyclotomic squaring reduces base-field multiplications while increasing reliance on additions and coefficient rearrangements.
+
+Since multiplications dominate computational cost, this optimization yields substantial performance improvements.
+
+In practice, cyclotomic squaring is significantly faster than standard extension-field squaring and is considered essential for efficient pairing implementations.
+
+---
+
+# 11. Relevance to Soroban-ZK-Std
+
+Within Soroban-constrained environments:
+
+* WASM size is limited,
+* instruction budgets are finite,
+* pairing operations must remain efficient.
+
+Cyclotomic squaring reduces:
+
+* arithmetic complexity,
+* instruction count,
+* multiplication overhead,
+* verifier execution cost.
+
+This optimization is therefore foundational for practical pairing verification inside Stellar smart contracts.
+
+---
+
+# 12. Security Considerations
+
+Cyclotomic squaring must preserve:
+
+* subgroup membership,
+* canonical coefficient representation,
+* constant-time execution.
+
+Incorrect subgroup handling may produce invalid pairing outputs or introduce soundness failures in higher-level protocols.
+
+All coefficient transformations should therefore be implemented deterministically and without data-dependent branching.
+
+---
+
+# 13. Intuition
+
+The optimization can be viewed as exploiting hidden symmetry.
+
+A generic element of $\mathbb{F}_{q^{12}}$ contains many independent coefficients. However, cyclotomic subgroup elements are highly structured.
+
+This structure means many terms in the squaring expansion are:
+
+* repeated,
+* related,
+* or algebraically dependent.
+
+Cyclotomic squaring removes redundant work by reusing these relationships rather than recomputing every interaction independently.
+
+---
+
+# 14. Summary
+
+Cyclotomic squaring is a specialized optimization for elements of the cyclotomic subgroup of $\mathbb{F}_{q^{12}}$ used during the hard part of pairing final exponentiation.
+
+The method exploits subgroup structure to reduce multiplication complexity and improve verifier efficiency.
+
+These optimizations are essential for performant BN254 pairing systems operating under constrained execution environments such as Soroban.
+
+---

--- a/docs/math/halo2_perm.mdx
+++ b/docs/math/halo2_perm.mdx
@@ -1,0 +1,249 @@
+---
+title: "Halo2 Permutation Argument"
+description: "Specification for row and column permutation constraints in Halo2"
+protocol: "25"
+cap: "CAP-0075"
+---
+
+# Halo2 Permutation Argument
+
+<div align="center">
+
+## Specification for Row and Column Permutation Constraints
+
+**Soroban-ZK-Std**
+
+</div>
+
+---
+
+# 1. Introduction
+
+Modern zero-knowledge proof systems frequently require proving that values appearing in different regions of a circuit are equal without explicitly adding equality constraints for every occurrence.
+
+Halo2 achieves this through a **permutation argument**, which allows cells across rows and columns to be linked by a global copy-constraint system.
+
+Rather than enforcing individual equalities directly, the protocol proves that two sets of values are identical up to a specified permutation.
+
+This document describes the mathematical foundation of the Halo2 permutation argument and its role in enforcing row and column consistency.
+
+---
+
+# 2. Motivation
+
+Consider two cells within a circuit:
+
+$$a = b$$
+
+A naive implementation would introduce a separate equality constraint for every copied value.
+
+As circuits scale, this becomes inefficient.
+
+Instead, Halo2 constructs a global permutation that tracks all cells participating in equality relationships and proves that the witness values respect that permutation.
+
+---
+
+# 3. Circuit Layout
+
+A Halo2 circuit consists of:
+
+* columns,
+* rows,
+* assigned witness values.
+
+Each cell is identified by $(c, r)$ where:
+
+* $c$ denotes the column,
+* $r$ denotes the row.
+
+Example:
+
+| Column A | Column B | Column C |
+| -------- | -------- | -------- |
+| $a_0$    | $b_0$    | $c_0$    |
+| $a_1$    | $b_1$    | $c_1$    |
+| $a_2$    | $b_2$    | $c_2$    |
+
+The permutation argument allows values from different cells to be declared equivalent.
+
+---
+
+# 4. Copy Constraints
+
+Suppose a circuit requires:
+
+$$a_i = b_j$$
+
+and
+
+$$b_j = c_k$$
+
+Rather than enforcing these individually, Halo2 places all participating cells into a permutation cycle.
+
+The protocol then proves that the values assigned to those positions are consistent.
+
+---
+
+# 5. Permutation Representation
+
+Let:
+
+$$S = \{s_1, s_2, \dots, s_n\}$$
+
+denote the ordered set of circuit positions.
+
+A permutation:
+
+$$\sigma : S \rightarrow S$$
+
+maps each position to another position in the same equality cycle.
+
+If two cells belong to the same copy-constraint set, they appear within the same permutation cycle.
+
+---
+
+# 6. Encoding Cell Positions
+
+Each circuit position is assigned a unique identifier.
+
+For a column $c$ and row $r$:
+
+$$\text{id}(c, r)$$
+
+uniquely identifies that location.
+
+These identifiers are incorporated into the permutation polynomial construction.
+
+This prevents ambiguity between cells that may contain identical values but belong to different locations.
+
+---
+
+# 7. Randomized Compression
+
+To prevent forgery, Halo2 introduces random verifier challenges $\beta$ and $\gamma$, which combine position identifiers and witness values into a single expression.
+
+For each position:
+
+$$v_i + \beta \cdot \text{id}_i + \gamma$$
+
+where:
+
+* $v_i$ is the witness value,
+* $\text{id}_i$ is the position identifier.
+
+Randomization ensures that invalid permutations are detected with overwhelming probability.
+
+---
+
+# 8. Grand Product Construction
+
+The core of the permutation argument is the grand product polynomial.
+
+Define $Z(X)$ such that:
+
+$$Z(0) = 1$$
+
+and recursively:
+
+$$Z(i+1) = Z(i) \cdot \frac{v_i + \beta\, \text{id}_i + \gamma}{v_i + \beta\, \sigma(\text{id}_i) + \gamma}$$
+
+for every circuit position.
+
+---
+
+# 9. Correctness Property
+
+If the witness values satisfy all copy constraints, then the numerator and denominator products are identical.
+
+Consequently:
+
+$$Z(n) = 1$$
+
+at the end of the permutation cycle.
+
+This condition proves that all equality relationships are respected.
+
+---
+
+# 10. Why the Argument Works
+
+Suppose a prover attempts to assign inconsistent values:
+
+$$a_i \neq b_j$$
+
+even though both positions belong to the same permutation cycle.
+
+The randomized terms involving $\beta$ and $\gamma$ cause the product identity to fail except with negligible probability.
+
+Thus, invalid copy assignments cannot satisfy the grand product constraint.
+
+---
+
+# 11. Row and Column Lookups
+
+The permutation system naturally supports equality relationships across:
+
+* different rows,
+* different columns,
+* different circuit regions.
+
+For example:
+
+$$(c_1, r_3) \leftrightarrow (c_5, r_{17})$$
+
+can be linked without introducing explicit pairwise equality constraints.
+
+This provides significant scalability benefits for large circuits.
+
+---
+
+# 12. Security Considerations
+
+The security of the permutation argument relies on:
+
+* sound polynomial commitments,
+* random verifier challenges,
+* correct construction of the permutation polynomial.
+
+An attacker must simultaneously satisfy all randomized product constraints, which is computationally infeasible without a valid witness assignment.
+
+---
+
+# 13. Intuition
+
+Imagine labeling every cell participating in an equality relationship.
+
+Instead of checking every equality individually, place all labels into a collection and verify that the collection remains unchanged after applying the declared permutation.
+
+If every copied value is correct, the collection remains identical.
+
+If even one value differs, the product relationship breaks and the proof fails.
+
+The permutation argument therefore transforms thousands of equality checks into a single compact algebraic verification.
+
+---
+
+# 14. Relevance to Halo2
+
+The permutation argument is one of the foundational components of Halo2.
+
+It enables:
+
+* efficient copy constraints,
+* flexible circuit wiring,
+* reduced constraint overhead,
+* scalable proof generation.
+
+Without permutation arguments, large circuits would require substantially more constraints and verification work.
+
+---
+
+# 15. Summary
+
+The Halo2 permutation argument provides a compact method for enforcing equality relationships across rows and columns of a circuit.
+
+By constructing a permutation polynomial and proving a randomized grand product identity, Halo2 verifies that all copy constraints are satisfied without introducing explicit equality constraints for every occurrence.
+
+This mechanism is fundamental to the efficiency and scalability of modern Halo2-based proof systems.
+
+---

--- a/docs/math/non_native_add.mdx
+++ b/docs/math/non_native_add.mdx
@@ -1,0 +1,231 @@
+---
+title: "Non-Native Field Addition with Carry Tracking"
+description: "Mathematical specification for foreign-field addition in ZK circuits"
+protocol: "25"
+cap: "CAP-0075"
+---
+
+# Non-Native Field Addition with Carry Tracking
+
+<div align="center">
+
+## Mathematical Specification for Foreign-Field Addition in ZK Circuits
+
+**Soroban-ZK-Std**
+
+</div>
+
+---
+
+# 1. Introduction
+
+In zero-knowledge systems, it is often necessary to perform arithmetic over a field that differs from the proving system's native field. Such arithmetic is referred to as **non-native field arithmetic** or **foreign-field arithmetic**.
+
+Because the target field modulus may exceed the size of a single native field element, foreign-field elements must be represented as a sequence of smaller components called **limbs**.
+
+This document specifies the mathematical constraints and carry-tracking rules required to safely perform non-native field addition inside a constraint system.
+
+---
+
+# 2. Limb Representation
+
+Let:
+
+* $p$ denote the modulus of the foreign field
+* $B$ denote the limb base
+* $n$ denote the number of limbs
+
+A foreign-field element $A$ is represented as:
+
+$$A = \sum_{i=0}^{n-1} a_i B^i$$
+
+where each limb satisfies:
+
+$$0 \le a_i < B$$
+
+Similarly, another element $C$ is represented as:
+
+$$C = \sum_{i=0}^{n-1} c_i B^i$$
+
+---
+
+# 3. Goal of Addition
+
+Given two foreign-field elements:
+
+$$A = (a_0, a_1, \dots, a_{n-1})$$
+
+$$C = (c_0, c_1, \dots, c_{n-1})$$
+
+we wish to compute:
+
+$$R = A + C$$
+
+while ensuring that:
+
+1. limb bounds remain valid,
+2. carries are propagated correctly,
+3. reconstruction equals canonical integer addition.
+
+---
+
+# 4. Carry-Tracking Addition
+
+Addition is performed independently on each limb.
+
+For each limb index $i$, define:
+
+$$s_i = a_i + c_i + k_i$$
+
+where:
+
+* $s_i$ is the intermediate sum,
+* $k_i$ is the incoming carry.
+
+The sum is decomposed into:
+
+$$s_i = r_i + k_{i+1}B$$
+
+where:
+
+* $r_i$ is the resulting limb,
+* $k_{i+1}$ is the outgoing carry.
+
+Thus:
+
+$$r_i = s_i \bmod B$$
+
+$$k_{i+1} = \left\lfloor \frac{s_i}{B} \right\rfloor$$
+
+---
+
+# 5. Constraint Formulation
+
+Inside a zero-knowledge circuit, the carry relation is enforced algebraically.
+
+For each limb:
+
+$$a_i + c_i + k_i - r_i = k_{i+1}B$$
+
+This constraint guarantees:
+
+* correctness of carry propagation,
+* correctness of limb decomposition,
+* consistency with integer addition.
+
+---
+
+# 6. Reconstruction Correctness
+
+The reconstructed result is:
+
+$$R = \sum_{i=0}^{n-1} r_i B^i$$
+
+Substituting the carry equation:
+
+$$a_i + c_i + k_i = r_i + k_{i+1}B$$
+
+and summing across all limbs yields:
+
+$$A + C = R + k_n B^n$$
+
+where $k_n$ is the final carry.
+
+This demonstrates that the limb decomposition preserves standard integer addition.
+
+---
+
+# 7. Carry Bounds
+
+To maintain soundness, carry values must remain bounded.
+
+Assuming:
+
+$$0 \le a_i < B$$
+
+$$0 \le c_i < B$$
+
+$$0 \le k_i \le 1$$
+
+then:
+
+$$s_i < 2B + 1$$
+
+which implies:
+
+$$k_{i+1} \in \{0, 1\}$$
+
+for sufficiently chosen limb bases.
+
+This boundedness property is essential for preventing invalid witness assignments.
+
+---
+
+# 8. Why Carry Tracking Matters
+
+Without explicit carry constraints, a prover could assign arbitrary limb values that satisfy local equations while failing to correspond to valid integer arithmetic.
+
+Carry tracking ensures:
+
+* arithmetic consistency,
+* canonical decomposition,
+* sound witness generation,
+* deterministic reconstruction.
+
+These guarantees are foundational for secure non-native arithmetic inside recursive proof systems and elliptic-curve operations.
+
+---
+
+# 9. Intuition
+
+Non-native addition behaves identically to ordinary positional addition.
+
+For example, in base 10:
+
+$$789 + 456$$
+
+produces carries during each digit addition:
+
+$$9 + 6 = 15$$
+
+Write:
+
+* $5$ as the current digit,
+* carry $1$ into the next position.
+
+Non-native field arithmetic applies the same principle using large cryptographic bases such as:
+
+$$B = 2^{16}, \quad 2^{32}, \quad 2^{64}$$
+
+instead of decimal digits.
+
+---
+
+# 10. Security Considerations
+
+All limb operations and carry propagation rules must be implemented in constant time.
+
+Failure to enforce bounded carries or canonical decomposition may permit:
+
+* invalid witness constructions,
+* malformed field representations,
+* soundness violations in recursive systems.
+
+For this reason, every limb decomposition constraint must be enforced explicitly inside the circuit.
+
+---
+
+# 11. Summary
+
+This specification defines a carry-tracked decomposition method for performing non-native field addition within zero-knowledge circuits.
+
+The construction guarantees:
+
+* correctness of reconstruction,
+* bounded carry propagation,
+* compatibility with limb-based representations,
+* algebraic enforceability inside constraint systems.
+
+These properties make the method suitable for efficient foreign-field arithmetic in constrained proving environments such as Soroban-compatible ZK systems.
+
+---

--- a/docs/math/rescue.mdx
+++ b/docs/math/rescue.mdx
@@ -1,0 +1,230 @@
+---
+title: "Rescue-Prime Hash Function"
+description: "State permutation and S-box inversion specification for the Rescue-Prime ZK-friendly hash"
+protocol: "25"
+cap: "CAP-0075"
+---
+
+# Rescue-Prime Hash Function
+
+<div align="center">
+
+## State Permutation and S-Box Inversion Specification
+
+**Soroban-ZK-Std**
+
+</div>
+
+---
+
+# 1. Introduction
+
+Rescue-Prime is an algebraic hash function designed specifically for zero-knowledge proof systems.
+
+Unlike traditional hash functions such as SHA-256, Rescue-Prime is constructed to minimize arithmetic circuit complexity while maintaining strong cryptographic security.
+
+Its design alternates between nonlinear transformations and linear mixing operations, producing a permutation that is efficient to verify inside finite-field constraint systems.
+
+This document specifies the state permutation process and the S-box inversion mechanism used by Rescue-Prime.
+
+---
+
+# 2. State Representation
+
+Rescue-Prime operates on a state consisting of $t$ field elements.
+
+The state is represented as:
+
+$$\mathbf{s} = (s_0, s_1, \ldots, s_{t-1})$$
+
+where $s_i \in \mathbb{F}_p$ and $\mathbb{F}_p$ denotes the underlying finite field.
+
+---
+
+# 3. Permutation Structure
+
+A Rescue-Prime permutation consists of multiple rounds.
+
+Each round applies:
+
+1. Nonlinear S-box layer
+2. Linear MDS matrix layer
+3. Round constant addition
+4. Inverse S-box layer
+5. Second MDS matrix layer
+6. Additional round constants
+
+This alternating structure ensures both diffusion and nonlinearity.
+
+---
+
+# 4. Round Constants
+
+For each round $r$, predefined constants are added to the state.
+
+Let:
+
+$$\mathbf{c}^{(r)} = (c_0^{(r)}, c_1^{(r)}, \ldots, c_{t-1}^{(r)})$$
+
+Then:
+
+$$\mathbf{s} \leftarrow \mathbf{s} + \mathbf{c}^{(r)}$$
+
+where addition is performed component-wise.
+
+Round constants prevent structural symmetries and strengthen resistance against cryptanalytic attacks.
+
+---
+
+# 5. Forward S-Box
+
+The primary nonlinear operation is exponentiation by a fixed exponent $\alpha$ chosen such that:
+
+$$\gcd(\alpha, p-1) = 1$$
+
+to ensure invertibility.
+
+The forward S-box is defined as:
+
+$$S(x) = x^\alpha$$
+
+and applied independently to every state element:
+
+$$s_i \leftarrow s_i^\alpha$$
+
+for all state coordinates.
+
+---
+
+# 6. MDS Matrix Mixing
+
+After the S-box layer, the state is multiplied by a Maximum Distance Separable (MDS) matrix $M$.
+
+The new state becomes:
+
+$$\mathbf{s}' = M\mathbf{s}$$
+
+This operation ensures that every output coordinate depends on every input coordinate.
+
+---
+
+# 7. Inverse S-Box
+
+A defining feature of Rescue-Prime is the use of an inverse nonlinear layer.
+
+Let $\alpha^{-1}$ be the multiplicative inverse of $\alpha$ modulo $p-1$, such that:
+
+$$\alpha \cdot \alpha^{-1} \equiv 1 \pmod{p-1}$$
+
+The inverse S-box is:
+
+$$S^{-1}(x) = x^{\alpha^{-1}}$$
+
+Applied component-wise:
+
+$$s_i \leftarrow s_i^{\alpha^{-1}}$$
+
+for every state element.
+
+---
+
+# 8. Why Inversion Works
+
+By Fermat's Little Theorem:
+
+$$x^{p-1} = 1$$
+
+for all nonzero $x \in \mathbb{F}_p$.
+
+Since $\alpha \cdot \alpha^{-1} \equiv 1 \pmod{p-1}$, we obtain:
+
+$$\left(x^\alpha\right)^{\alpha^{-1}} = x$$
+
+Thus the inverse S-box exactly reverses the forward S-box.
+
+---
+
+# 9. Complete Round Definition
+
+One Rescue-Prime round may be expressed as:
+
+$$\mathbf{s} \rightarrow S(\mathbf{s}) \rightarrow M\mathbf{s} \rightarrow \mathbf{s} + \mathbf{c}_1 \rightarrow S^{-1}(\mathbf{s}) \rightarrow M\mathbf{s} \rightarrow \mathbf{s} + \mathbf{c}_2$$
+
+where:
+
+* $S$ is the forward S-box,
+* $S^{-1}$ is the inverse S-box,
+* $M$ is the MDS matrix.
+
+---
+
+# 10. Security Intuition
+
+The forward S-box introduces nonlinearity.
+
+The MDS layer spreads information across the entire state.
+
+The inverse S-box introduces additional nonlinearity while preserving efficient algebraic representation.
+
+The alternating structure provides strong diffusion while maintaining low constraint complexity in zero-knowledge circuits.
+
+---
+
+# 11. Efficiency in ZK Systems
+
+Rescue-Prime was designed specifically for arithmetic circuits.
+
+Its operations consist primarily of:
+
+* field additions,
+* field multiplications,
+* exponentiation by fixed exponents,
+* matrix multiplication.
+
+These operations translate efficiently into Rank-1 Constraint Systems (R1CS), PLONK-style circuits, and Halo2 circuits.
+
+---
+
+# 12. Relevance to Soroban-ZK-Std
+
+Rescue-Prime provides a ZK-friendly alternative to conventional cryptographic hash functions.
+
+Applications include:
+
+* Merkle trees,
+* commitment schemes,
+* nullifier generation,
+* private state transitions,
+* recursive proof systems.
+
+Its algebraic structure makes it particularly suitable for constrained execution environments and proof-generation pipelines.
+
+---
+
+# 13. Security Considerations
+
+Implementations must ensure:
+
+* constant-time field arithmetic,
+* correct exponentiation routines,
+* valid MDS matrices,
+* deterministic round constant generation.
+
+Incorrect parameter selection may weaken diffusion or introduce structural vulnerabilities.
+
+---
+
+# 14. Summary
+
+Rescue-Prime is a permutation-based hash function optimized for zero-knowledge systems.
+
+Its security derives from alternating:
+
+* forward S-box transformations,
+* MDS mixing,
+* inverse S-box transformations,
+* round constant injections.
+
+The use of both exponentiation and inverse exponentiation distinguishes Rescue-Prime from many other ZK-friendly hash functions and enables efficient implementation within finite-field arithmetic circuits.
+
+---

--- a/docs/polynomial-operations.mdx
+++ b/docs/polynomial-operations.mdx
@@ -1,0 +1,579 @@
+---
+title: "API Reference: Polynomial Operations"
+description: "Defining and evaluating dense and sparse polynomials over the BN254 scalar field"
+protocol: "25"
+cap: "CAP-0075"
+---
+
+# API Reference: Polynomial Operations
+
+> **Defining and evaluating dense and sparse polynomials over the BN254 scalar field.**
+
+## Overview
+
+Polynomials are the backbone of modern zero-knowledge proof systems. Whether you're constructing Quadratic Arithmetic Programs (QAPs) for Groth16, building polynomial commitment schemes, or performing FFT-based operations for PLONK, efficient polynomial arithmetic over finite fields is essential.
+
+This document defines the API for working with polynomials over BN254's scalar field `Fr`, using the field arithmetic primitives from `zk-core`.
+
+## Mathematical Background
+
+A polynomial of degree `d` over field `Fr` is:
+
+```
+p(x) = a₀ + a₁·x + a₂·x² + ... + aₐ·xᵈ
+```
+
+where each coefficient `aᵢ ∈ Fr` (the BN254 scalar field with modulus `r`).
+
+### Two Representations
+
+| Representation | Storage | Best For |
+|---------------|---------|----------|
+| **Dense** | `Vec<Fr>` of all coefficients (including zeros) | Low-degree polynomials, FFT operations |
+| **Sparse** | `Vec<(usize, Fr)>` of `(exponent, coefficient)` pairs | High-degree polynomials with few non-zero terms |
+
+## Dense Polynomials
+
+### Type Definition
+
+```rust
+use zk_core::{Bn254, Fr, SafeFrom};
+use ethnum::u256;
+
+/// A dense polynomial represented by its coefficient vector.
+/// Coefficients are ordered from the constant term (index 0)
+/// to the highest-degree term.
+///
+/// Example: [3, 0, 5] represents 3 + 0·x + 5·x² = 3 + 5x²
+pub struct DensePolynomial {
+    /// Coefficient vector where coeffs[i] is the coefficient of x^i
+    pub coeffs: Vec<u256>,
+}
+```
+
+### Construction
+
+#### `from_coefficients_vec`
+
+```rust
+impl DensePolynomial {
+    /// Creates a polynomial from a vector of coefficients.
+    ///
+    /// The vector is ordered from the constant term to the
+    /// highest-degree term: `[a₀, a₁, a₂, ...]`
+    ///
+    /// Trailing zeros are automatically stripped to maintain
+    /// a canonical representation.
+    ///
+    /// # Example
+    /// ```rust
+    /// // p(x) = 5 + 3x + 2x²
+    /// let p = DensePolynomial::from_coefficients_vec(vec![
+    ///     u256::from(5u8),
+    ///     u256::from(3u8),
+    ///     u256::from(2u8),
+    /// ]);
+    /// assert_eq!(p.degree(), 2);
+    /// ```
+    pub fn from_coefficients_vec(mut coeffs: Vec<u256>) -> Self {
+        // Remove trailing zeros for canonical form
+        while coeffs.last() == Some(&u256::from(0u8)) {
+            coeffs.pop();
+        }
+        Self { coeffs }
+    }
+}
+```
+
+#### `from_coefficients_slice`
+
+```rust
+impl DensePolynomial {
+    /// Creates a polynomial from a slice of coefficients.
+    ///
+    /// Clones the slice into an owned vector and strips
+    /// trailing zeros.
+    ///
+    /// # Example
+    /// ```rust
+    /// let coeffs = [u256::from(1u8), u256::from(0u8), u256::from(4u8)];
+    /// let p = DensePolynomial::from_coefficients_slice(&coeffs);
+    /// // p(x) = 1 + 4x²
+    /// ```
+    pub fn from_coefficients_slice(coeffs: &[u256]) -> Self {
+        Self::from_coefficients_vec(coeffs.to_vec())
+    }
+}
+```
+
+#### `zero` and `one`
+
+```rust
+impl DensePolynomial {
+    /// Returns the zero polynomial (additive identity).
+    pub fn zero() -> Self {
+        Self { coeffs: vec![] }
+    }
+
+    /// Returns the constant polynomial 1 (multiplicative identity).
+    pub fn one() -> Self {
+        Self { coeffs: vec![u256::from(1u8)] }
+    }
+
+    /// Returns true if this is the zero polynomial.
+    pub fn is_zero(&self) -> bool {
+        self.coeffs.is_empty()
+    }
+}
+```
+
+### Evaluation
+
+#### `evaluate` — Horner's Method
+
+The most efficient way to evaluate a polynomial at a single point. Horner's method rewrites:
+
+```
+p(x) = a₀ + x·(a₁ + x·(a₂ + ... + x·aₐ))
+```
+
+This requires only `d` multiplications and `d` additions (no exponentiation).
+
+```rust
+impl DensePolynomial {
+    /// Evaluates the polynomial at point `x` using Horner's method.
+    ///
+    /// All arithmetic is performed modulo the BN254 scalar field
+    /// modulus `r` using `Bn254::add` and `Bn254::mul`.
+    ///
+    /// # Complexity
+    /// - Time: O(d) where d = degree
+    /// - Space: O(1)
+    ///
+    /// # Example
+    /// ```rust
+    /// // p(x) = 2 + 3x + x²
+    /// let p = DensePolynomial::from_coefficients_vec(vec![
+    ///     u256::from(2u8),
+    ///     u256::from(3u8),
+    ///     u256::from(1u8),
+    /// ]);
+    ///
+    /// // p(5) = 2 + 3·5 + 25 = 42
+    /// let result = p.evaluate(u256::from(5u8));
+    /// assert_eq!(result, u256::from(42u8));
+    /// ```
+    pub fn evaluate(&self, x: u256) -> u256 {
+        if self.is_zero() {
+            return u256::from(0u8);
+        }
+
+        // Horner's method: start from the highest-degree term
+        let mut result = u256::from(0u8);
+        for coeff in self.coeffs.iter().rev() {
+            // result = result * x + coeff
+            result = Bn254::mul(result, x);
+            result = Bn254::add(result, *coeff);
+        }
+        result
+    }
+}
+```
+
+### Arithmetic Operations
+
+#### `degree`
+
+```rust
+impl DensePolynomial {
+    /// Returns the degree of the polynomial.
+    ///
+    /// The zero polynomial has degree 0 by convention.
+    /// A constant polynomial `c ≠ 0` has degree 0.
+    /// `a₀ + a₁x + ... + aₐxᵈ` has degree `d`.
+    pub fn degree(&self) -> usize {
+        if self.coeffs.is_empty() {
+            0
+        } else {
+            self.coeffs.len() - 1
+        }
+    }
+}
+```
+
+#### `add`
+
+```rust
+impl DensePolynomial {
+    /// Adds two polynomials coefficient-wise.
+    ///
+    /// All additions are modular: `(a + b) mod r`.
+    ///
+    /// # Example
+    /// ```rust
+    /// let p = DensePolynomial::from_coefficients_vec(vec![
+    ///     u256::from(1u8), u256::from(2u8)
+    /// ]); // 1 + 2x
+    ///
+    /// let q = DensePolynomial::from_coefficients_vec(vec![
+    ///     u256::from(3u8), u256::from(0u8), u256::from(4u8)
+    /// ]); // 3 + 4x²
+    ///
+    /// let sum = p.add(&q);
+    /// // sum = 4 + 2x + 4x²
+    /// ```
+    pub fn add(&self, other: &Self) -> Self {
+        let max_len = core::cmp::max(self.coeffs.len(), other.coeffs.len());
+        let mut result = Vec::with_capacity(max_len);
+
+        for i in 0..max_len {
+            let a = self.coeffs.get(i).copied().unwrap_or(u256::from(0u8));
+            let b = other.coeffs.get(i).copied().unwrap_or(u256::from(0u8));
+            result.push(Bn254::add(a, b));
+        }
+
+        Self::from_coefficients_vec(result)
+    }
+}
+```
+
+#### `sub`
+
+```rust
+impl DensePolynomial {
+    /// Subtracts `other` from `self`, coefficient-wise.
+    ///
+    /// All subtractions are modular: `(a - b) mod r`.
+    /// Uses `Bn254::sub` which handles underflow by wrapping.
+    pub fn sub(&self, other: &Self) -> Self {
+        let max_len = core::cmp::max(self.coeffs.len(), other.coeffs.len());
+        let mut result = Vec::with_capacity(max_len);
+
+        for i in 0..max_len {
+            let a = self.coeffs.get(i).copied().unwrap_or(u256::from(0u8));
+            let b = other.coeffs.get(i).copied().unwrap_or(u256::from(0u8));
+            result.push(Bn254::sub(a, b));
+        }
+
+        Self::from_coefficients_vec(result)
+    }
+}
+```
+
+#### `mul` (Schoolbook Multiplication)
+
+```rust
+impl DensePolynomial {
+    /// Multiplies two polynomials using schoolbook multiplication.
+    ///
+    /// For polynomials of degree `m` and `n`, the result has
+    /// degree `m + n` and requires O(m·n) field multiplications.
+    ///
+    /// # Note
+    /// For large polynomials, consider using NTT/FFT-based
+    /// multiplication for O(n log n) performance. Schoolbook
+    /// multiplication is preferred for small polynomials due
+    /// to its lower constant factor within Soroban's budget.
+    pub fn mul(&self, other: &Self) -> Self {
+        if self.is_zero() || other.is_zero() {
+            return Self::zero();
+        }
+
+        let result_len = self.coeffs.len() + other.coeffs.len() - 1;
+        let mut result = vec![u256::from(0u8); result_len];
+
+        for (i, a) in self.coeffs.iter().enumerate() {
+            for (j, b) in other.coeffs.iter().enumerate() {
+                let product = Bn254::mul(*a, *b);
+                result[i + j] = Bn254::add(result[i + j], product);
+            }
+        }
+
+        Self::from_coefficients_vec(result)
+    }
+}
+```
+
+#### `scalar_mul`
+
+```rust
+impl DensePolynomial {
+    /// Multiplies every coefficient by a scalar value.
+    ///
+    /// # Example
+    /// ```rust
+    /// let p = DensePolynomial::from_coefficients_vec(vec![
+    ///     u256::from(2u8), u256::from(3u8)
+    /// ]); // 2 + 3x
+    ///
+    /// let scaled = p.scalar_mul(u256::from(5u8));
+    /// // scaled = 10 + 15x
+    /// ```
+    pub fn scalar_mul(&self, scalar: u256) -> Self {
+        let coeffs: Vec<u256> = self.coeffs
+            .iter()
+            .map(|c| Bn254::mul(*c, scalar))
+            .collect();
+        Self::from_coefficients_vec(coeffs)
+    }
+}
+```
+
+## Sparse Polynomials
+
+Sparse polynomials are ideal when a polynomial has very few non-zero terms relative to its degree. For example, `x^1000 + 1` has only 2 non-zero terms.
+
+### Type Definition
+
+```rust
+/// A sparse polynomial represented by non-zero terms only.
+/// Each term is a `(exponent, coefficient)` pair.
+///
+/// Example: [(0, 1), (1000, 1)] represents 1 + x^1000
+pub struct SparsePolynomial {
+    /// Non-zero terms as (exponent, coefficient) pairs.
+    /// Terms are sorted by exponent in ascending order.
+    pub terms: Vec<(usize, u256)>,
+}
+```
+
+### Construction
+
+#### `from_terms`
+
+```rust
+impl SparsePolynomial {
+    /// Creates a sparse polynomial from an iterator of
+    /// `(exponent, coefficient)` pairs.
+    ///
+    /// - Filters out zero coefficients
+    /// - Combines duplicate exponents via addition
+    /// - Sorts terms by exponent
+    ///
+    /// # Example
+    /// ```rust
+    /// // p(x) = 7 + 3x^5 + x^100
+    /// let p = SparsePolynomial::from_terms(vec![
+    ///     (0, u256::from(7u8)),
+    ///     (5, u256::from(3u8)),
+    ///     (100, u256::from(1u8)),
+    /// ]);
+    /// assert_eq!(p.degree(), 100);
+    /// ```
+    pub fn from_terms(mut terms: Vec<(usize, u256)>) -> Self {
+        // Remove zero coefficients
+        terms.retain(|(_, c)| *c != u256::from(0u8));
+
+        // Sort by exponent
+        terms.sort_by_key(|(exp, _)| *exp);
+
+        // Combine duplicate exponents
+        let mut combined: Vec<(usize, u256)> = Vec::new();
+        for (exp, coeff) in terms {
+            if let Some(last) = combined.last_mut() {
+                if last.0 == exp {
+                    last.1 = Bn254::add(last.1, coeff);
+                    continue;
+                }
+            }
+            combined.push((exp, coeff));
+        }
+
+        Self { terms: combined }
+    }
+}
+```
+
+### Evaluation
+
+#### `evaluate` — Exponentiation per term
+
+```rust
+impl SparsePolynomial {
+    /// Evaluates the sparse polynomial at point `x`.
+    ///
+    /// For each term `(e, c)`, computes `c · x^e` using
+    /// `Bn254::pow` and accumulates the result.
+    ///
+    /// # Complexity
+    /// - Time: O(k · log(max_exp)) where k = number of terms
+    /// - Space: O(1)
+    ///
+    /// # Example
+    /// ```rust
+    /// // p(x) = 1 + x^3
+    /// let p = SparsePolynomial::from_terms(vec![
+    ///     (0, u256::from(1u8)),
+    ///     (3, u256::from(1u8)),
+    /// ]);
+    ///
+    /// // p(2) = 1 + 8 = 9
+    /// let result = p.evaluate(u256::from(2u8));
+    /// assert_eq!(result, u256::from(9u8));
+    /// ```
+    pub fn evaluate(&self, x: u256) -> u256 {
+        let mut result = u256::from(0u8);
+
+        for &(exp, coeff) in &self.terms {
+            let x_pow = if exp == 0 {
+                u256::from(1u8)
+            } else {
+                Bn254::pow(x, u256::from(exp as u64))
+            };
+            let term = Bn254::mul(coeff, x_pow);
+            result = Bn254::add(result, term);
+        }
+
+        result
+    }
+
+    /// Returns the degree of the sparse polynomial.
+    pub fn degree(&self) -> usize {
+        self.terms.last().map(|(exp, _)| *exp).unwrap_or(0)
+    }
+
+    /// Returns true if this is the zero polynomial.
+    pub fn is_zero(&self) -> bool {
+        self.terms.is_empty()
+    }
+}
+```
+
+### Converting Between Representations
+
+```rust
+impl From<SparsePolynomial> for DensePolynomial {
+    /// Converts a sparse polynomial to dense form.
+    ///
+    /// Allocates a coefficient vector of size `degree + 1`,
+    /// initializes all entries to zero, then fills in the
+    /// non-zero terms.
+    fn from(sparse: SparsePolynomial) -> Self {
+        if sparse.is_zero() {
+            return Self::zero();
+        }
+
+        let degree = sparse.degree();
+        let mut coeffs = vec![u256::from(0u8); degree + 1];
+
+        for (exp, coeff) in sparse.terms {
+            coeffs[exp] = coeff;
+        }
+
+        Self::from_coefficients_vec(coeffs)
+    }
+}
+
+impl From<DensePolynomial> for SparsePolynomial {
+    /// Converts a dense polynomial to sparse form.
+    ///
+    /// Iterates over all coefficients and collects only
+    /// the non-zero ones with their indices.
+    fn from(dense: DensePolynomial) -> Self {
+        let terms: Vec<(usize, u256)> = dense.coeffs
+            .into_iter()
+            .enumerate()
+            .filter(|(_, c)| *c != u256::from(0u8))
+            .collect();
+
+        Self { terms }
+    }
+}
+```
+
+## Integration with `zk-core`
+
+All polynomial arithmetic uses `zk-core`'s BN254 field operations:
+
+| Operation | Function | Description |
+|-----------|----------|-------------|
+| Addition | `Bn254::add(a, b)` | `(a + b) mod r` |
+| Subtraction | `Bn254::sub(a, b)` | `(a - b) mod r` with underflow wrapping |
+| Multiplication | `Bn254::mul(a, b)` | `(a · b) mod r` via schoolbook method |
+| Exponentiation | `Bn254::pow(base, exp)` | `base^exp mod r` via square-and-multiply |
+| Inversion | `Bn254::invert(a)` | `a^(r-2) mod r` via Fermat's little theorem |
+
+### Field Modulus
+
+The BN254 scalar field modulus `r`:
+
+```
+r = 21888242871839275222246405745257275088548364400416034343698204186575808495617
+```
+
+All polynomial coefficients and evaluation points must be in `[0, r)`.
+
+## Complete Example
+
+```rust
+use ethnum::u256;
+use zk_core::Bn254;
+
+// Define p(x) = 1 + 2x + 3x²
+let p = DensePolynomial::from_coefficients_vec(vec![
+    u256::from(1u8),
+    u256::from(2u8),
+    u256::from(3u8),
+]);
+
+// Define q(x) = 4 + 5x
+let q = DensePolynomial::from_coefficients_vec(vec![
+    u256::from(4u8),
+    u256::from(5u8),
+]);
+
+// Addition: (1 + 2x + 3x²) + (4 + 5x) = 5 + 7x + 3x²
+let sum = p.add(&q);
+assert_eq!(sum.evaluate(u256::from(0u8)), u256::from(5u8));
+
+// Multiplication: (1 + 2x + 3x²)(4 + 5x)
+// = 4 + 5x + 8x + 10x² + 12x² + 15x³
+// = 4 + 13x + 22x² + 15x³
+let product = p.mul(&q);
+assert_eq!(product.degree(), 3);
+
+// Evaluate at x = 1:
+// p(1) = 1 + 2 + 3 = 6
+// q(1) = 4 + 5 = 9
+// product(1) = p(1) * q(1) = 6 * 9 = 54
+assert_eq!(product.evaluate(u256::from(1u8)), u256::from(54u8));
+
+// Sparse polynomial: s(x) = 1 + x^1000
+let s = SparsePolynomial::from_terms(vec![
+    (0, u256::from(1u8)),
+    (1000, u256::from(1u8)),
+]);
+
+// s(0) = 1 + 0 = 1
+assert_eq!(s.evaluate(u256::from(0u8)), u256::from(1u8));
+
+// s(1) = 1 + 1 = 2
+assert_eq!(s.evaluate(u256::from(1u8)), u256::from(2u8));
+```
+
+## Performance Considerations
+
+### Dense vs Sparse: When to Use Which
+
+| Scenario | Recommendation |
+|----------|---------------|
+| QAP witness polynomials (degree < 100) | **Dense** — lower overhead, better cache locality |
+| Vanishing polynomials `x^n - 1` | **Sparse** — only 2 non-zero terms regardless of `n` |
+| Polynomial interpolation (Lagrange) | **Dense** — all coefficients typically non-zero |
+| Polynomial commitments (KZG) | **Dense** — requires access to all coefficients |
+| Selector polynomials in PLONK | **Sparse** — often mostly zeros |
+
+### Soroban WASM Budget
+
+Within Soroban's 64KB WASM limit and 400M instruction budget:
+
+- **Schoolbook multiplication** of two degree-`d` polynomials costs `O(d²)` field multiplications
+- Each `Bn254::mul` is a 256-bit modular multiplication (~200 instructions)
+- **Practical limit:** degree ~100 polynomials can be multiplied within budget
+- For higher degrees, consider off-chain computation with on-chain verification
+
+### Memory
+
+- Dense polynomial of degree `d`: `(d+1) × 32 bytes` for coefficients
+- Sparse polynomial with `k` terms: `k × 40 bytes` (8 bytes exponent + 32 bytes coefficient)
+- For `d = 1000, k = 5`: sparse uses 200 bytes vs dense's 32,032 bytes

--- a/docs/zk-cryptography-glossary.mdx
+++ b/docs/zk-cryptography-glossary.mdx
@@ -1,0 +1,251 @@
+---
+title: "ZK Cryptography Glossary"
+description: "A plain-English reference for zero-knowledge cryptography terminology used throughout Soroban-ZK-Std"
+protocol: "25"
+cap: "CAP-0075"
+---
+
+# ZK Cryptography Glossary
+
+> **A plain-English reference for zero-knowledge cryptography terminology used throughout Soroban-ZK-Std.**
+
+---
+
+## A — Arithmetic Circuit
+
+An **arithmetic circuit** is a computational model where a program is broken down into addition and multiplication gates over a finite field. Think of it as a flowchart where each node is either `+` or `×`, and the wires carry numbers (field elements).
+
+In ZK proving systems, the statement being proved (e.g., "I know a secret preimage of this hash") is first compiled into an arithmetic circuit. The circuit is then translated into a set of polynomial constraints that the prover must satisfy.
+
+> **Analogy:** Like building a circuit board where every component is either an adder or a multiplier, and you want to prove that the whole board computes the right answer without revealing the inputs.
+
+---
+
+## B — BN254 (alt_bn128)
+
+BN254 (also called **alt_bn128**) is an elliptic curve commonly used in zero-knowledge cryptography. Its defining feature is that it supports **bilinear pairings** — a special mathematical operation that is the foundation of efficient ZK proof systems like Groth16.
+
+The "254" refers to the bit length of the prime field. Key properties:
+- **Base field modulus (p):** 21888242871839275222246405745257275088696311157297823662689037894645226208583
+- **Scalar field modulus (r):** 21888242871839275222246405745257275088548364400416034343698204186575808495617
+
+BN254 is the curve natively supported by Stellar Protocol 25's CAP-0075 host functions.
+
+> **Analogy:** BN254 is like a special type of gear that lets you "pair" two numbers together in a way that enables complex proofs. Stellar picked this particular gear because it's well-studied and efficient.
+
+---
+
+## E — ElGamal Encryption
+
+An **asymmetric (public-key) encryption scheme** built on top of elliptic curve Diffie-Hellman. In Soroban-ZK-Std, ElGamal is used for **Viewing Keys** — allowing regulators to decrypt transaction amounts while keeping them hidden from the public.
+
+The ciphertext consists of two points `(C1, C2)` on the BN254 curve. Given the recipient's public key `P = x·G`:
+- `C1 = r·G` (ephemeral public key)
+- `C2 = M + r·P` (message blinded by shared secret)
+
+Anyone with the private key `x` can recover `M = C2 - x·C1`.
+
+> **Analogy:** Like a locked box where everyone can see the box (C1) and the locked message (C2), but only the regulator has the key to open it.
+
+
+### Extension Field
+
+An **extension field** is a larger field built on top of a smaller base field. For BN254:
+- **Fq** — the base field (elements are single numbers modulo p)
+- **Fq²** — a quadratic extension field (elements are pairs `(c0, c1)` representing `c0 + c1·u`, where `u` is a formal square root of a non-square in Fq)
+
+G2 points live in Fq², meaning their coordinates are pairs of numbers rather than single numbers. This is why G2 serialization (128 bytes) is twice as long as G1 serialization (64 bytes).
+
+> **Analogy:** Like complex numbers extend real numbers by adding `i = √-1`. Fq² extends Fq by adding an element that behaves like a square root of some fixed non-square value.
+
+---
+
+## G — G1 and G2
+
+In pairing-based cryptography, the elliptic curve has two related groups:
+- **G1** — Points on the BN254 curve over the base field Fq (64 bytes serialized)
+- **G2** — Points on the same curve over the extension field Fq² (128 bytes serialized)
+
+Pairings take one point from G1 and one from G2 and produce an output in a target group GT.
+
+> **Analogy:** Think of G1 and G2 as two different types of keys. A pairing is a special lock that requires one key of each type to work.
+
+### Groth16
+
+**Groth16** is a zero-knowledge proving system that produces very small proofs (only 3 group elements = ~200 bytes) with fast verification (a single multi-pairing check). It requires a **trusted setup** ceremony to generate the proving and verification keys.
+
+Pros:
+- Smallest proof size of any general-purpose ZK system
+- Fastest verification (constant-time, just a pairing check)
+- Well-studied and widely deployed
+
+Cons:
+- Requires a trusted setup (ceremony must be completed honestly)
+- Circuit-specific setup (new circuit = new ceremony)
+
+> **Analogy:** Groth16 is like a pre-assembled lock that a locksmith (trusted setup) built once. Anyone can quickly check if a key works, but building a new lock requires calling the locksmith again.
+
+---
+
+## K — KZG Polynomial Commitment
+
+**KZG** (Kate-Zaverucha-Goldberg) is a polynomial commitment scheme using bilinear pairings. A prover commits to a polynomial and can later reveal evaluations at specific points along with a proof that the evaluation is correct.
+
+KZG commitments are:
+- **Succinct:** The commitment is a single group element, regardless of polynomial degree
+- **Transparent with setup:** Requires a structured reference string (SRS) from a trusted setup
+
+> **Analogy:** Like sealing a recipe in an envelope. Later, you can open a tiny window to show just one ingredient, and the seal proves you didn't change the recipe.
+
+
+## M — Merkle Tree
+
+A **Merkle tree** is a hash-based data structure used for efficient membership proofs. Each leaf is a piece of data, each internal node is the hash of its two children, and the root is a single hash representing the entire tree.
+
+In Soroban-ZK-Std, Merkle trees are used in shielded asset contracts to maintain the set of valid deposits without revealing which specific deposit a user is spending.
+
+> **Analogy:** Like having a list of everyone in a building. The Merkle root is like a fingerprint of the entire list. You can prove you're on the list without saying your name — just by showing your branch of the tree.
+
+---
+
+## N — Nullifier
+
+A **nullifier** is a unique identifier that prevents double-spending in privacy systems. When a user spends a shielded asset, they reveal a nullifier that is cryptographically tied to that specific deposit. The system records the nullifier as "spent" so the same deposit cannot be spent twice.
+
+The nullifier is computationally infeasible to link back to the original deposit without knowing the user's secret key.
+
+> **Analogy:** Like tearing a ticket stub in half when you enter a venue. The torn half proves you used the ticket, but nobody can tell which ticket you originally had.
+
+---
+
+## P — Pairing (Bilinear Pairing)
+
+A **bilinear pairing** is a function `e: G1 × G2 → GT` with the property:
+
+```
+e(a·P, b·Q) = e(P, Q)^(a·b)
+```
+
+This bilinearity is the secret sauce that powers many ZK systems. It allows a verifier to combine multiple checks into a single equation.
+
+Stellar provides a native `bn254_multi_pairing_check` host function (CAP-0075) that evaluates `e(A₁, B₁) · e(A₂, B₂) · ... · e(Aₙ, Bₙ) == 1` in a single atomic operation — **190× faster** than a software-only implementation.
+
+> **Analogy:** A pairing is like a special handshake between two points. The magic property is that doing the handshake with doubled points is the same as doing the handshake twice — which lets you combine many checks into one.
+
+### PLONK
+
+**PLONK** (Permutations over Lagrange-bases for Oecumenical Non-interactive arguments of Knowledge) is a universal zk-SNARK that does not require a circuit-specific trusted setup. Instead, it uses a single structured reference string (SRS) that works for any circuit up to a certain size.
+
+PLONK is more flexible than Groth16 (universal setup) but produces larger proofs and has slightly slower verification.
+
+> **Analogy:** If Groth16 is a custom-built lock for each door, PLONK is a universal lock that can be programmed to fit any door — you just need a master key (the SRS) created once.
+
+
+## Q — QAP (Quadratic Arithmetic Program)
+
+A **Quadratic Arithmetic Program** is a way of representing an arithmetic circuit as a set of polynomials. This representation is used by Groth16 and other SNARKs to convert circuit satisfaction into a polynomial divisibility check.
+
+The QAP transforms the statement "this circuit is satisfied" into "these polynomials divide evenly," which can be efficiently verified with a pairing check.
+
+> **Analogy:** Like translating a blueprint into a musical score. The QAP lets the verifier "listen" to one note (the pairing check) and confirm the whole song is correct.
+
+---
+
+## S — SNARK
+
+**SNARK** stands for **Succinct Non-interactive ARgument of Knowledge**:
+- **Succinct:** Proofs are small (often a few hundred bytes) and fast to verify
+- **Non-interactive:** The prover sends a single message; no back-and-forth required
+- **Argument:** Soundness is computational (a computationally bounded prover cannot cheat)
+- **Knowledge:** The prover demonstrates knowledge of a secret witness
+
+Groth16 and PLONK are both types of SNARKs.
+
+### SNARK vs. STARK
+
+| Feature | SNARK | STARK |
+|---------|-------|-------|
+| Proof size | ~200 bytes | ~100 KB |
+| Verification | Very fast (pairing check) | Slower |
+| Setup | Requires trusted setup (or universal SRS) | Transparent (no setup) |
+| Post-quantum | No (uses elliptic curves) | Yes (uses hash functions) |
+| Gas cost on Stellar | Low (native pairing) | Higher (software-only hashes) |
+
+> **Analogy:** A SNARK is like a tiny key that opens a lock. A STARK is like a large blueprint that proves the lock was built correctly — no secret key needed, but it's much bigger.
+
+---
+
+## T — Trusted Setup
+
+A **trusted setup** is a ceremony that generates the proving and verification keys for a ZK system. It involves multiple participants who each contribute randomness, and as long as at least one participant is honest and destroys their secret, the setup is secure.
+
+Groth16 requires a circuit-specific trusted setup, while PLONK can use a universal setup that works for any circuit.
+
+> **Analogy:** Like having a group of people each mix a secret ingredient into a master recipe. As long as at least one person doesn't peek, the final recipe is secure.
+
+
+## V — Viewing Key
+
+A **viewing key** is a cryptographic mechanism that allows selective disclosure of private data. In Soroban-ZK-Std, ElGamal encryption is used to create viewing keys for regulators:
+
+1. The transfer amount is encrypted with the regulator's public key
+2. The encrypted value `(C1, C2)` is posted on-chain alongside the ZK proof
+3. Only the regulator (holding the private key) can decrypt and audit the amount
+4. The public sees only cryptographic noise
+
+This provides **configurable privacy** — transactions are private from the public but transparent to authorized auditors.
+
+> **Analogy:** Like a voting booth where the ballot is sealed in an envelope. Everyone can see that a vote was cast (the proof), only election officials can open the envelope to count it (viewing key), and no one can link the vote to the voter (nullifier).
+
+---
+
+## W — Witness
+
+In ZK terminology, the **witness** is the secret information that the prover wants to prove knowledge of, without revealing it. Examples:
+- The private key corresponding to a public key
+- The preimage of a hash
+- The path in a Merkle tree from a leaf to the root
+
+The witness, together with the public inputs, satisfies the arithmetic circuit constraints.
+
+> **Analogy:** Like knowing the solution to a Sudoku puzzle. The witness is the filled-in grid; the public statement is that the grid is valid. You can prove you have a valid solution without showing any numbers.
+
+---
+
+## Z — ZkError
+
+`ZkError` is the error type used throughout Soroban-ZK-Std. It provides meaningful failure information without panicking:
+
+```rust
+pub enum ZkError {
+    InvalidInput,   // Bad input data (e.g., empty pairs array)
+    DeserializationFailed,  // Could not parse byte data into a curve point
+    ArithmeticError,  // Field arithmetic overflow or invalid result
+}
+```
+
+> **Why no panics?** In Soroban smart contracts, panics waste the user's gas. By returning `Result<T, ZkError>`, developers can handle errors gracefully and refund unused gas when appropriate.
+
+
+---
+
+## Quick Reference Card
+
+| Term | Definition | Used In |
+|------|-----------|---------|
+| **Arithmetic Circuit** | Computation model of +/- gates over a field | All ZK systems |
+| **BN254** | Elliptic curve with pairings | Pairing checks, Groth16 |
+| **ElGamal** | Public-key encryption on elliptic curves | Viewing keys |
+| **Extension Field** | Larger field built from a base field (e.g., Fq²) | G2 points |
+| **G1/G2** | Two related groups for pairings | Pairing checks |
+| **Groth16** | ZK proving system with smallest proofs | Shielded transfers |
+| **KZG** | Polynomial commitment using pairings | PLONK, custom circuits |
+| **Merkle Tree** | Hash tree for efficient membership proofs | Deposit sets |
+| **Nullifier** | Unique identifier preventing double-spending | Shielded transfers |
+| **Pairing** | Bilinear map e: G1×G2→GT | All pairing-based ZK |
+| **PLONK** | Universal zk-SNARK (no circuit-specific setup) | Alternative to Groth16 |
+| **SNARK** | Succinct Non-interactive ARgument of Knowledge | Proof verification |
+| **Trusted Setup** | Ceremony generating proving/verification keys | Groth16, KZG |
+| **Viewing Key** | Selective disclosure mechanism | Regulatory compliance |
+| **Witness** | Secret information the prover knows | All ZK proofs |
+| **ZkError** | Library error type for graceful failure | Error handling |


### PR DESCRIPTION
Changes Made
Converted 9 documentation files from `.md` to `.mdx` format:

Main Documentation Directory:
- `docs/ASP_Integration.md` → `docs/ASP_Integration.mdx`
- `docs/cap0075-integration-guide.md` → `docs/cap0075-integration-guide.mdx`
- `docs/getting-started-guide.md` → `docs/getting-started-guide.mdx`
- `docs/polynomial-operations.md` → `docs/polynomial-operations.mdx`
- `docs/zk-cryptography-glossary.md` → `docs/zk-cryptography-glossary.mdx`

 Math Subdirectory:
- `docs/math/rescue.md` → `docs/math/rescue.mdx`
- `docs/math/non_native_add.md` → `docs/math/non_native_add.mdx`
- `docs/math/halo2_perm.md` → `docs/math/halo2_perm.mdx`
- `docs/math/cyclotomic.md` → `docs/math/cyclotomic.mdx`

Frontmatter Added

Each converted file now includes proper YAML frontmatter:

```yaml
---
title: "[Document Title]"
description: "[Brief description of content]"
protocol: "25"
cap: "CAP-0075"
---
```

Frontmatter Fields:
- `title`: Descriptive document title
- `description`: Clear, concise summary of document purpose
- `protocol`: "25" (Stellar Protocol 25 / X-Ray upgrade)
- `cap`: "CAP-0075" (Capacity Enhancement Proposal reference)