### PR TITLE
feat(zk-soroban): instance-storage caching of BN254 constants (#124)

### DIFF
--- a/crates/zk-soroban/src/cache.rs
+++ b/crates/zk-soroban/src/cache.rs
@@ -1,0 +1,144 @@
+//! Instance-storage caching of recurring BN254 cryptographic constants (Issue #124).
+//!
+//! The BN254 Poseidon2 permutation depends on a fixed matrix diagonal and 64
+//! round-constant rows, and field arithmetic depends on the Fr modulus. These
+//! values are deterministic and identical on every contract invocation, yet the
+//! pure builders in [`crate::poseidon2`] rebuild them from code on each call.
+//!
+//! This module caches them in the contract's `StorageType::Instance` using lazy
+//! initialisation: the first read within a contract computes the constant and
+//! writes it to instance storage; later reads return the stored copy. The
+//! instance TTL is bumped on every access so the cache stays live for as long
+//! as the contract is in active use.
+//!
+//! ## Security
+//! Instance storage is owned exclusively by the contract — external callers
+//! cannot write to it — so a cached constant cannot be tampered with by a
+//! third party. Because every value is also fully recomputable from code, a
+//! cache miss (for example after TTL expiry) is recovered transparently with
+//! no loss of correctness.
+
+use soroban_sdk::{contracttype, Env, Vec, U256};
+
+/// Lower TTL bound (in ledgers) for the instance entry. When the remaining
+/// time-to-live drops below this threshold, the entry is extended back up to
+/// [`INSTANCE_BUMP_AMOUNT`]. ~1 day at 5s ledger close time.
+const INSTANCE_LIFETIME_THRESHOLD: u32 = 17_280;
+
+/// Target TTL (in ledgers) the instance entry is extended to on access.
+/// ~30 days at 5s ledger close time.
+const INSTANCE_BUMP_AMOUNT: u32 = 518_400;
+
+/// Keys for the recurring cryptographic constants cached in instance storage.
+#[contracttype]
+#[derive(Clone)]
+pub enum ConstantKey {
+    /// BN254 Poseidon2 (t=3) 64 round-constant rows.
+    Poseidon2RoundConstants,
+    /// BN254 Poseidon2 internal matrix diagonal (M_I − I) = [1, 1, 2].
+    Poseidon2MatDiag,
+    /// BN254 Fr field modulus r.
+    FrModulus,
+}
+
+/// Bump the instance TTL so the cached constants stay live during active use.
+fn bump(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+}
+
+/// Return the cached BN254 Poseidon2 round constants, computing and storing
+/// them on the first call within the contract.
+pub fn round_constants(env: &Env) -> Vec<Vec<U256>> {
+    let store = env.storage().instance();
+    let value = match store.get(&ConstantKey::Poseidon2RoundConstants) {
+        Some(rc) => rc,
+        None => {
+            let rc = crate::poseidon2::round_constants(env);
+            store.set(&ConstantKey::Poseidon2RoundConstants, &rc);
+            rc
+        }
+    };
+    bump(env);
+    value
+}
+
+/// Return the cached BN254 Poseidon2 matrix diagonal, computing and storing it
+/// on the first call within the contract.
+pub fn mat_diag(env: &Env) -> Vec<U256> {
+    let store = env.storage().instance();
+    let value = match store.get(&ConstantKey::Poseidon2MatDiag) {
+        Some(mat) => mat,
+        None => {
+            let mat = crate::poseidon2::mat_diag(env);
+            store.set(&ConstantKey::Poseidon2MatDiag, &mat);
+            mat
+        }
+    };
+    bump(env);
+    value
+}
+
+/// Return the cached BN254 Fr modulus, computing and storing it on the first
+/// call within the contract.
+pub fn fr_modulus(env: &Env) -> U256 {
+    let store = env.storage().instance();
+    let value = match store.get(&ConstantKey::FrModulus) {
+        Some(m) => m,
+        None => {
+            let m = crate::poseidon2::fr_modulus(env);
+            store.set(&ConstantKey::FrModulus, &m);
+            m
+        }
+    };
+    bump(env);
+    value
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ZkContract;
+    use soroban_sdk::Env;
+
+    fn env() -> Env {
+        let e = Env::default();
+        e.cost_estimate().budget().reset_unlimited();
+        e
+    }
+
+    #[test]
+    fn round_constants_lazy_init_then_cache_hit() {
+        let env = env();
+        let id = env.register(ZkContract, ());
+        env.as_contract(&id, || {
+            let store = env.storage().instance();
+            // Cold: nothing cached yet.
+            assert!(!store.has(&ConstantKey::Poseidon2RoundConstants));
+
+            // First read populates the cache and matches the pure builder.
+            let first = round_constants(&env);
+            assert!(store.has(&ConstantKey::Poseidon2RoundConstants));
+            assert_eq!(first, crate::poseidon2::round_constants(&env));
+
+            // Second read is a cache hit returning identical data.
+            let second = round_constants(&env);
+            assert_eq!(first, second);
+        });
+    }
+
+    #[test]
+    fn mat_diag_and_modulus_are_cached() {
+        let env = env();
+        let id = env.register(ZkContract, ());
+        env.as_contract(&id, || {
+            assert_eq!(mat_diag(&env), crate::poseidon2::mat_diag(&env));
+            assert_eq!(fr_modulus(&env), crate::poseidon2::fr_modulus(&env));
+
+            let store = env.storage().instance();
+            assert!(store.has(&ConstantKey::Poseidon2MatDiag));
+            assert!(store.has(&ConstantKey::FrModulus));
+        });
+    }
+}

--- a/crates/zk-soroban/src/lib.rs
+++ b/crates/zk-soroban/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+pub mod cache;
 pub mod pairing;
 pub mod poseidon2;
 
@@ -71,6 +72,21 @@ impl ZkContract {
         // This forces the compiler to include the ethnum and zk-core logic
         env.is_bn254_scalar(val)
     }
+
+    /// Poseidon2 hash of a list of BN254 field elements, using the
+    /// instance-storage cache for the round constants and matrix diagonal
+    /// (Issue #124).
+    ///
+    /// The first invocation populates the cache from code; later invocations
+    /// reuse the constants stored in `StorageType::Instance` instead of
+    /// rebuilding them on every call.
+    pub fn poseidon2_hash(env: Env, inputs: soroban_sdk::Vec<U256>) -> U256 {
+        let mut sponge = poseidon2::Poseidon2Sponge::new_cached(&env);
+        for input in inputs.iter() {
+            sponge.absorb(core::slice::from_ref(&input));
+        }
+        sponge.squeeze()
+    }
 }
 
 #[cfg(test)]
@@ -121,5 +137,31 @@ mod tests {
         let val = U256::from_be_bytes(&env, &bytes);
         let result = env.fr_from_u256(val);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn poseidon2_hash_matches_uncached_and_reuses_cache() {
+        let env = Env::default();
+        env.cost_estimate().budget().reset_unlimited();
+        let id = env.register(ZkContract, ());
+        let client = ZkContractClient::new(&env, &id);
+
+        let inputs = soroban_sdk::vec![&env, U256::from_u128(&env, 1), U256::from_u128(&env, 2)];
+
+        // The cached on-chain hash equals the pure (uncached) library hash.
+        let raw = [U256::from_u128(&env, 1), U256::from_u128(&env, 2)];
+        let expected = poseidon2::hash_to_field(&env, &raw);
+        assert_eq!(client.poseidon2_hash(&inputs), expected);
+
+        // A second invocation hits the populated instance cache and is stable.
+        assert_eq!(client.poseidon2_hash(&inputs), expected);
+
+        // The constants are present in the contract's instance storage.
+        env.as_contract(&id, || {
+            let store = env.storage().instance();
+            assert!(store.has(&cache::ConstantKey::Poseidon2RoundConstants));
+            assert!(store.has(&cache::ConstantKey::Poseidon2MatDiag));
+            assert!(store.has(&cache::ConstantKey::FrModulus));
+        });
     }
 }

--- a/crates/zk-soroban/src/poseidon2.rs
+++ b/crates/zk-soroban/src/poseidon2.rs
@@ -20,7 +20,7 @@ const RATE: u32 = 2;
 // ── BN254 Fr modulus (used for field-addition during absorption) ───────────────
 // r = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001
 
-fn fr_modulus(env: &Env) -> U256 {
+pub(crate) fn fr_modulus(env: &Env) -> U256 {
     u(
         env,
         0x30644e72e131a029b85045b68181585d,
@@ -39,12 +39,12 @@ fn u(env: &Env, hi: u128, lo: u128) -> U256 {
 }
 
 /// Field addition mod r: (a + b) mod r.
-/// Both inputs must be < r.
-fn field_add(env: &Env, a: &U256, b: &U256) -> U256 {
+/// Both inputs must be < r. The modulus is passed in so callers can reuse a
+/// cached value instead of rebuilding it on every addition.
+fn field_add(a: &U256, b: &U256, modulus: &U256) -> U256 {
     let sum = a.add(b);
-    let r = fr_modulus(env);
-    if sum >= r {
-        sum.sub(&r)
+    if sum >= *modulus {
+        sum.sub(modulus)
     } else {
         sum
     }
@@ -65,7 +65,7 @@ fn u256_to_fr(challenge: U256) -> Result<Fr, ZkError> {
 // ── BN254 t=3 Poseidon2 constants ─────────────────────────────────────────────
 
 /// Internal matrix diagonal (M_I − I) for t=3 BN254: [1, 1, 2].
-fn mat_diag(env: &Env) -> Vec<U256> {
+pub(crate) fn mat_diag(env: &Env) -> Vec<U256> {
     vec![
         env,
         U256::from_u128(env, 1),
@@ -76,7 +76,7 @@ fn mat_diag(env: &Env) -> Vec<U256> {
 
 /// 64 round-constant rows (4 full + 56 partial + 4 full) for BN254 Poseidon2 t=3.
 /// Source: soroban-env-host-25.0.1 / poseidon2_instance_bn254.rs (RC3).
-fn round_constants(env: &Env) -> Vec<Vec<U256>> {
+pub(crate) fn round_constants(env: &Env) -> Vec<Vec<U256>> {
     let z = U256::from_u128(env, 0);
 
     // 3-element full-round row
@@ -529,17 +529,53 @@ pub struct Poseidon2Sponge {
     state: Vec<U256>,
     /// Next rate slot to write into during absorption.
     rate_idx: u32,
+    /// Internal matrix diagonal, materialised once per sponge instead of on
+    /// every permutation.
+    mat: Vec<U256>,
+    /// 64 round-constant rows, materialised once per sponge.
+    rc: Vec<Vec<U256>>,
+    /// BN254 Fr modulus, reused across all field additions.
+    modulus: U256,
 }
 
 impl Poseidon2Sponge {
-    /// Create a new sponge with zeroed state.
+    /// Create a new sponge with zeroed state, building the BN254 constants
+    /// from code (no contract storage required).
+    ///
+    /// The round constants and matrix diagonal are computed once here and
+    /// reused across every [`Poseidon2Sponge::absorb`]/[`Poseidon2Sponge::squeeze`]
+    /// permutation, rather than being rebuilt on each permutation.
     pub fn new(env: &Env) -> Self {
+        Self::with_constants(env, mat_diag(env), round_constants(env), fr_modulus(env))
+    }
+
+    /// Create a new sponge whose BN254 constants are sourced from the contract
+    /// instance storage cache (Issue #124).
+    ///
+    /// On the first invocation within a contract the constants are computed and
+    /// written to `StorageType::Instance`; subsequent invocations read them back
+    /// from storage instead of rebuilding them. Must be called from within a
+    /// contract invocation context (it touches instance storage).
+    pub fn new_cached(env: &Env) -> Self {
+        Self::with_constants(
+            env,
+            crate::cache::mat_diag(env),
+            crate::cache::round_constants(env),
+            crate::cache::fr_modulus(env),
+        )
+    }
+
+    /// Shared constructor: build a zeroed sponge around the supplied constants.
+    fn with_constants(env: &Env, mat: Vec<U256>, rc: Vec<Vec<U256>>, modulus: U256) -> Self {
         let z = U256::from_u128(env, 0);
         let state = vec![env, z.clone(), z.clone(), z];
         Self {
             env: env.clone(),
             state,
             rate_idx: 0,
+            mat,
+            rc,
+            modulus,
         }
     }
 
@@ -547,7 +583,7 @@ impl Poseidon2Sponge {
     pub fn absorb(&mut self, inputs: &[U256]) {
         for input in inputs {
             let cur = self.state.get(self.rate_idx).unwrap();
-            let next = field_add(&self.env, &cur, input);
+            let next = field_add(&cur, input, &self.modulus);
             self.state.set(self.rate_idx, next);
             self.rate_idx += 1;
             if self.rate_idx == RATE {
@@ -570,8 +606,6 @@ impl Poseidon2Sponge {
 
     fn permute(&mut self) {
         let field = symbol_short!("BN254");
-        let mat = mat_diag(&self.env);
-        let rc = round_constants(&self.env);
         self.state = self.env.crypto_hazmat().poseidon2_permutation(
             &self.state,
             field,
@@ -579,8 +613,8 @@ impl Poseidon2Sponge {
             D,
             ROUNDS_F,
             ROUNDS_P,
-            &mat,
-            &rc,
+            &self.mat,
+            &self.rc,
         );
     }
 }
@@ -593,6 +627,18 @@ impl Poseidon2Sponge {
 /// Uses capacity-zero sponge initialisation.
 pub fn hash_to_field(env: &Env, inputs: &[U256]) -> U256 {
     let mut sponge = Poseidon2Sponge::new(env);
+    sponge.absorb(inputs);
+    sponge.squeeze()
+}
+
+/// Instance-cached variant of [`hash_to_field`] (Issue #124).
+///
+/// Identical output to [`hash_to_field`], but the BN254 round constants and
+/// matrix diagonal are loaded from (and lazily populated into) the contract
+/// instance storage cache rather than rebuilt from code. Must be called from
+/// within a contract invocation context.
+pub fn hash_to_field_cached(env: &Env, inputs: &[U256]) -> U256 {
+    let mut sponge = Poseidon2Sponge::new_cached(env);
     sponge.absorb(inputs);
     sponge.squeeze()
 }


### PR DESCRIPTION
## Summary
Implements **Issue #124 — [Core] Implement Instance Caching**: utilise Soroban `StorageType::Instance` to cache recurring cryptographic constants securely.

The BN254 Poseidon2 permutation rebuilt its **64 round-constant rows** and the **matrix diagonal** on *every* `permute()` call, and `field_add` rebuilt the **Fr modulus** on every addition. These values are fixed and identical on every invocation — ideal candidates for instance caching.

## Changes
- **New `cache` module** (`crates/zk-soroban/src/cache.rs`): a `#[contracttype]` `ConstantKey` enum plus lazy instance-storage getters (`round_constants`, `mat_diag`, `fr_modulus`). The first read within a contract computes the constant and writes it to `StorageType::Instance`; later reads return the stored copy. The instance TTL is extended on every access so the cache stays live during active use.
- **`Poseidon2Sponge`** now materialises its constants **once at construction** (`new`) rather than on each permutation. A new **`new_cached`** constructor (and `hash_to_field_cached` helper) sources the constants from the instance cache.
- **`ZkContract::poseidon2_hash`** — a contract entry point that exercises the cache on-chain.

## Security
Instance storage is owned exclusively by the contract, so cached constants cannot be tampered with by external callers. Because every value is fully recomputable from code, a cache miss (e.g. after TTL expiry) is recovered transparently with no loss of correctness.

## Testing
All green locally:
- `cache::round_constants_lazy_init_then_cache_hit` — cold miss populates storage, warm hit returns identical data, and both equal the pure builder.
- `cache::mat_diag_and_modulus_are_cached` — mat-diag and modulus cached + present in instance storage.
- `poseidon2_hash_matches_uncached_and_reuses_cache` — on-chain hash equals the pure `hash_to_field`, is stable across calls, and all three keys are present in instance storage.
- `cargo fmt --check` ✅ · `cargo clippy --all-targets --all-features -- -D warnings` ✅ · `cargo test --release` ✅
- `cargo build --target wasm32v1-none --release -p verifier-sample` ✅ — **20,972 bytes** (< 64 KB).

## Note on CI
This PR touches `crates/**/src/**.rs`, so the **Documentation Standards Check** workflow also runs. Its `MDX/Markdown Lint` / `Docs Site Build` jobs depend on the frontend `pnpm-lock.yaml` fix in #259 (not yet merged). Once #259 lands on `main`, those docs jobs go green here too; the Rust `ci.yml` checks for this PR are unaffected.

Closes #124
