### PR TITLE
docs: add KZG commitment generation spec with Pippenger MSM algorithm

### DIFF
--- a/frontend/content/docs/math-and-cryptography/kzg_commit.mdx
+++ b/frontend/content/docs/math-and-cryptography/kzg_commit.mdx
@@ -1,0 +1,315 @@
+---
+title: "KZG Commitment Generation"
+description: "Multi-scalar multiplication algorithm for generating KZG polynomial commitments"
+protocol: "25"
+cap: "CAP-0075"
+---
+
+# KZG Commitment Generation
+
+<div align="center">
+
+## Multi-Scalar Multiplication Algorithm for Polynomial Commitment over BN254
+
+**Soroban-ZK-Std | zk-core**
+
+</div>
+
+---
+
+# 1. Introduction
+
+KZG commitments (Kate-Zaverucha-Goldberg) are a polynomial commitment scheme that
+allows a prover to commit to a polynomial with a single elliptic curve point. A
+verifier can later request an opening proof at any evaluation point, and the prover
+responds with another single curve point. Both the commitment and the verification
+require no interaction beyond this exchange.
+
+The commitment step is the most computationally expensive part of the scheme. It
+requires evaluating a **multi-scalar multiplication (MSM)** over the BN254 $G_1$
+group: computing a weighted sum of curve points where the weights are polynomial
+coefficients.
+
+This document specifies the MSM algorithm used to generate KZG commitments, the
+trusted setup structure it depends on, and the correctness requirements that
+must hold for commitment soundness.
+
+---
+
+# 2. Preliminaries
+
+## 2.1 Groups and Fields
+
+Let:
+
+* $\mathbb{F}_r$ denote the BN254 scalar field with modulus $r$
+* $G_1$ denote the BN254 prime-order subgroup of the elliptic curve $E(\mathbb{F}_q)$
+* $G$ denote the generator of $G_1$
+* $[k]$ denote scalar multiplication of $G$ by $k \in \mathbb{F}_r$, i.e. $[k] = k \cdot G$
+
+## 2.2 Polynomial
+
+Let $f(X) \in \mathbb{F}_r[X]$ be a polynomial of degree at most $n - 1$:
+
+$$f(X) = \sum_{i=0}^{n-1} a_i X^i, \qquad a_i \in \mathbb{F}_r$$
+
+The coefficient vector is:
+
+$$\mathbf{a} = (a_0, a_1, \ldots, a_{n-1})$$
+
+---
+
+# 3. Trusted Setup
+
+KZG commitments require a **structured reference string (SRS)**, generated from a
+secret scalar $\tau \in \mathbb{F}_r$ that must be discarded after setup.
+
+The SRS for $G_1$ is the sequence of curve points:
+
+$$\mathbf{G} = \bigl([\tau^0],\, [\tau^1],\, [\tau^2],\, \ldots,\, [\tau^{n-1}]\bigr)$$
+
+where:
+
+$$[\tau^i] = \tau^i \cdot G \in G_1$$
+
+These points are publicly known after the trusted setup ceremony. The secret $\tau$
+is unknown to all parties. The SRS is fixed for a given maximum polynomial degree $n - 1$.
+
+---
+
+# 4. Commitment Definition
+
+Given polynomial $f$ with coefficients $\mathbf{a}$ and SRS $\mathbf{G}$, the
+KZG commitment is:
+
+$$C = \sum_{i=0}^{n-1} a_i \cdot [\tau^i]$$
+
+This is the inner product of the scalar vector $\mathbf{a}$ and the curve-point
+vector $\mathbf{G}$. The result $C \in G_1$ is a single elliptic curve point.
+
+Computing this sum directly is a **multi-scalar multiplication (MSM)**: given
+$n$ scalars and $n$ curve points, compute their weighted sum.
+
+---
+
+# 5. Naive MSM and Its Cost
+
+The straightforward approach computes each $a_i \cdot [\tau^i]$ independently via
+double-and-add scalar multiplication, then accumulates the results:
+
+~~~
+C = identity
+for i = 0 to n-1:
+    C = C + scalar_mul(a_i, G[i])
+~~~
+
+Each scalar multiplication over BN254 $G_1$ costs approximately $2 \log_2 r \approx 510$
+group operations (doublings and additions). For $n$ terms, the total is:
+
+$$\text{Naive cost} \approx 510n \text{ group operations}$$
+
+This is prohibitively expensive for large $n$ inside Soroban's instruction budget.
+
+---
+
+# 6. Pippenger MSM Algorithm
+
+The Pippenger algorithm reduces MSM cost by grouping scalars into windows and
+accumulating curve points bucket by bucket. This avoids redundant scalar
+multiplication work across terms.
+
+## 6.1 Window Decomposition
+
+Choose a window size $w$ (typically $w \approx \log_2 n / 2$).
+
+Decompose each scalar $a_i$ into $\lceil \log_2 r / w \rceil$ windows of $w$ bits each:
+
+$$a_i = \sum_{j=0}^{W-1} a_i^{(j)} \cdot 2^{jw}, \qquad W = \left\lceil \frac{\log_2 r}{w} \right\rceil$$
+
+where each digit $a_i^{(j)} \in \{0, 1, \ldots, 2^w - 1\}$.
+
+## 6.2 Bucket Accumulation
+
+For each window $j$ and each possible digit value $b \in \{1, \ldots, 2^w - 1\}$,
+define the bucket:
+
+$$B_j^{(b)} = \sum_{\substack{i=0 \\ a_i^{(j)} = b}}^{n-1} [\tau^i]$$
+
+Each point $[\tau^i]$ is added to exactly one bucket per window, determined by
+its scalar digit in that window.
+
+## 6.3 Bucket Reduction
+
+Within each window $j$, reduce the $2^w - 1$ buckets into a single point using
+the running sum technique:
+
+$$S_j = \sum_{b=1}^{2^w - 1} b \cdot B_j^{(b)}$$
+
+This is computed without any scalar multiplications -- only additions -- by
+accumulating from the highest bucket downward:
+
+~~~
+acc = identity
+S_j = identity
+for b = 2^w - 1 downto 1:
+    acc = acc + B_j[b]
+    S_j = S_j + acc
+~~~
+
+## 6.4 Window Combination
+
+Combine the per-window results across all $W$ windows:
+
+$$C = \sum_{j=0}^{W-1} 2^{jw} \cdot S_j$$
+
+This final combination is computed via repeated doublings and additions:
+
+~~~
+C = S_{W-1}
+for j = W-2 downto 0:
+    for k = 0 to w-1:
+        C = point_double(C)
+    C = C + S_j
+~~~
+
+---
+
+# 7. Full Pippenger Algorithm
+
+~~~
+Input:
+  scalars = (a_0, a_1, ..., a_{n-1})   in Fr^n
+  points  = (G_0, G_1, ..., G_{n-1})   in G1^n   [SRS]
+  w                                               [window size in bits]
+
+Output:
+  C = sum of a_i * G_i                  in G1
+
+Steps:
+
+  W = ceil(log2(r) / w)
+
+  // --- Phase 1: Bucket accumulation ---
+  for j = 0 to W-1:
+    initialize buckets B[1..2^w - 1] = identity
+
+    for i = 0 to n-1:
+      digit = (a_i >> (j * w)) & (2^w - 1)
+      if digit != 0:
+        B[digit] = B[digit] + points[i]
+
+  // --- Phase 2: Bucket reduction ---
+    acc = identity
+    S[j] = identity
+    for b = 2^w - 1 downto 1:
+      acc  = acc + B[b]
+      S[j] = S[j] + acc
+
+  // --- Phase 3: Window combination ---
+  C = S[W-1]
+  for j = W-2 downto 0:
+    for k = 0 to w-1:
+      C = point_double(C)
+    C = C + S[j]
+
+  return C
+~~~
+
+---
+
+# 8. Complexity Analysis
+
+| Phase | Cost |
+|-------|------|
+| Bucket accumulation | $n \cdot W$ point additions |
+| Bucket reduction | $W \cdot 2^w$ point additions |
+| Window combination | $W \cdot w$ point doublings |
+| **Total** | $O\!\left(\dfrac{n}{\log n}\right)$ group operations |
+
+For BN254 with $\log_2 r \approx 254$ and optimal $w \approx \log_2 n / 2$,
+Pippenger achieves roughly a $\log_2(n) / 2$ speedup over the naive approach.
+For $n = 2^{20}$, this represents approximately a 10x reduction in group operations.
+
+---
+
+# 9. Correctness Invariant
+
+The commitment $C$ is correct when:
+
+1. The SRS points satisfy $[\tau^i] = \tau^i \cdot G$ for the same secret $\tau$
+   used across all indices.
+2. Bucket accumulation assigns each point $[\tau^i]$ to exactly one bucket per
+   window based on the scalar digit -- no point is omitted or double-counted.
+3. Bucket reduction computes the weighted sum without scalar multiplications.
+4. Window combination applies the correct power-of-two shift $2^{jw}$ per window.
+5. All group operations are performed on points verified to be in $G_1$.
+
+---
+
+# 10. Subgroup Membership
+
+Every SRS point and every intermediate accumulation result must lie in $G_1$.
+
+For BN254, subgroup membership of a point $P = (x, y)$ is verified by checking:
+
+$$r \cdot P = \mathcal{O}$$
+
+where $\mathcal{O}$ is the point at infinity. Points failing this check must be
+rejected before entering the MSM.
+
+Accepting malformed points would allow a prover to produce commitments that
+verify against an inconsistent SRS, breaking binding.
+
+---
+
+# 11. Soroban Constraints
+
+Within the Soroban execution environment:
+
+* Point additions and doublings must be constant-time to prevent timing leakage.
+* The window size $w$ should be chosen at compile time based on the expected
+  polynomial degree, not derived from runtime input.
+* SRS points should be validated for subgroup membership once during setup,
+  not on every commitment call.
+* Intermediate bucket arrays of size $2^w$ must fit within available stack space
+  given the WASM memory constraints.
+
+---
+
+# 12. Relationship to Other Components
+
+| Component | Relationship |
+|-----------|-------------|
+| Jacobian to affine conversion | Point additions in Pippenger are cheaper in Jacobian coordinates; final result is converted to affine |
+| Fermat-based modular inversion | Required for the Jacobian-to-affine conversion of the final commitment point |
+| Sparse Fq12 multiplication | Unrelated; operates during the Miller loop, not during commitment generation |
+| NTT over Fr | Used upstream to compute polynomial coefficients before commitment |
+
+---
+
+# 13. Security Considerations
+
+* The trusted setup secret $\tau$ must be permanently discarded after SRS generation.
+  Any party that retains $\tau$ can produce false openings.
+* Commitment binding holds under the $q$-Strong Diffie-Hellman assumption over BN254.
+* All group operations must be constant-time. Variable-time point addition or
+  scalar processing leaks information about polynomial coefficients.
+* The SRS must be validated before use. Accepting arbitrary curve points as SRS
+  elements allows targeted attacks on the binding property.
+
+---
+
+# 14. Summary
+
+The KZG commitment to a polynomial $f$ of degree $n - 1$ is a single $G_1$ point
+computed as a multi-scalar multiplication against the trusted setup SRS.
+
+The key properties are:
+
+* Commitment: $C = \sum_{i=0}^{n-1} a_i \cdot [\tau^i] \in G_1$
+* Algorithm: Pippenger MSM with window size $w \approx \log_2 n / 2$
+* Cost: $O(n / \log n)$ group operations versus $O(n \log r)$ for naive scalar mul
+* Correctness: requires valid SRS, correct bucket assignment, and subgroup-checked inputs
+* Safety: constant-time group operations, compile-time window size
+
+---

--- a/frontend/lib/navigation.ts
+++ b/frontend/lib/navigation.ts
@@ -33,6 +33,7 @@ export const navigation: NavItem[] = [
       { title: "Halo2 Perm", href: "/docs/halo2_perm" },
       { title: "Non Native Add", href: "/docs/non_native_add" },
       { title: "FRI", href: "/docs/fri" },
+      { title: "KZG Commitment Generation", href: "/docs/kzg_commit" },
     ],
   },
   {


### PR DESCRIPTION
## Description

Adds a formal mathematical specification for KZG commitment generation over BN254.
The document covers the trusted setup structure, the commitment definition as a
multi-scalar multiplication, the Pippenger MSM algorithm with bucket accumulation
and window combination, complexity analysis, and subgroup membership requirements.

## Linked Issue

Fixes #97

## Mathematical/Cryptographic Impact

A KZG commitment is a single $G_1$ point computed as the inner product of polynomial
coefficients and SRS points. The Pippenger algorithm reduces this from $O(n \log r)$
naive scalar multiplications to $O(n / \log n)$ group operations by batching scalars
into windows and accumulating into buckets. Documentation-only PR -- no cryptographic
primitives modified.

## PR Checklist

- [ ] I have run `make all` locally and everything passes.
- [ ] My code strictly adheres to `no_std` (no standard library imports).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have not introduced any `.unwrap()` or `panic!()` calls (using custom errors instead).
- [ ] My changes do not push the core WASM binary over the 64KB limit.