### PR TITLE
feat: implement KZG commitment generation (Issue #112)

### DIFF
--- a/crates/soroban-zk-core/benches/g1_ops.rs
+++ b/crates/soroban-zk-core/benches/g1_ops.rs
@@ -154,6 +154,40 @@ fn bench_fr_mul(c: &mut Criterion) {
     });
 }
 
+/// Benchmark: KZG commitment generation for small polynomial sizes.
+fn bench_kzg_commit(c: &mut Criterion) {
+    use soroban_zk_core::{kzg_commit, DensePolynomial};
+
+    let g = gen();
+    let two_g = two_g();
+
+    // Size 2: polynomial [a, b] against SRS [G, 2G]
+    let srs_2 = [g, two_g];
+    let poly_2 =
+        DensePolynomial::<4>::from_coefficients_slice(&[u256::from(3u64), u256::from(5u64)])
+            .unwrap();
+
+    c.bench_function("KzgCommit_size2", |b| {
+        b.iter(|| black_box(kzg_commit(black_box(&poly_2), black_box(&srs_2))));
+    });
+
+    // Size 4: polynomial [a, b, c, d] against SRS [G, 2G, 3G, 4G]
+    let three_g = Bn254::g1_scalar_mul(G1Projective::from(g), u256::from(3u64)).to_affine();
+    let four_g = Bn254::g1_scalar_mul(G1Projective::from(g), u256::from(4u64)).to_affine();
+    let srs_4 = [g, two_g, three_g, four_g];
+    let poly_4 = DensePolynomial::<4>::from_coefficients_slice(&[
+        u256::from(1u64),
+        u256::from(2u64),
+        u256::from(3u64),
+        u256::from(4u64),
+    ])
+    .unwrap();
+
+    c.bench_function("KzgCommit_size4", |b| {
+        b.iter(|| black_box(kzg_commit(black_box(&poly_4), black_box(&srs_4))));
+    });
+}
+
 criterion_group!(
     benches,
     bench_g1_add,
@@ -163,5 +197,6 @@ criterion_group!(
     bench_fq_invert,
     bench_to_affine,
     bench_fr_mul,
+    bench_kzg_commit,
 );
 criterion_main!(benches);

--- a/crates/soroban-zk-core/src/lib.rs
+++ b/crates/soroban-zk-core/src/lib.rs
@@ -490,3 +490,31 @@ impl G1Projective {
         }
     }
 }
+
+/// KZG commitment generation.
+///
+/// Computes `C = sum(a_i * srs[i])` where `a_i` are the polynomial
+/// coefficients and `srs[i]` are the structured reference string G1 points.
+///
+/// Returns the group identity if the polynomial is zero.
+/// Returns [`ZkError::InvalidInput`] if the polynomial length exceeds the
+/// SRS length.
+///
+/// All computation is stack-allocated with zero heap usage.
+pub fn kzg_commit<const N: usize>(
+    poly: &DensePolynomial<N>,
+    srs: &[G1Affine],
+) -> Result<G1Affine, ZkError> {
+    if poly.len > srs.len() {
+        return Err(ZkError::InvalidInput);
+    }
+
+    let mut acc = G1Projective::identity();
+
+    for (coeff, srs_point) in poly.coeffs().iter().zip(srs.iter()) {
+        let term = Bn254::g1_scalar_mul(G1Projective::from(*srs_point), *coeff);
+        acc = acc.add(&term);
+    }
+
+    Ok(acc.to_affine())
+}

--- a/crates/soroban-zk-core/tests/kzg_kat.rs
+++ b/crates/soroban-zk-core/tests/kzg_kat.rs
@@ -1,0 +1,144 @@
+use ethnum::u256;
+use soroban_zk_core::{kzg_commit, Bn254, DensePolynomial, G1Affine, G1Projective, ZkError};
+
+/// BN254 G1 generator (x=1, y=2).
+fn g1_generator() -> G1Affine {
+    G1Affine {
+        x: u256::from(1u8),
+        y: u256::from(2u8),
+    }
+}
+
+/// 2*G on BN254.
+fn g1_two() -> G1Affine {
+    G1Projective::from(g1_generator()).double().to_affine()
+}
+
+/// 3*G on BN254.
+fn g1_three() -> G1Affine {
+    G1Projective::from(g1_generator())
+        .double()
+        .add(&G1Projective::from(g1_generator()))
+        .to_affine()
+}
+
+/// KZG with a single coefficient: C = a * G.
+#[test]
+fn kzg_single_coefficient() {
+    let srs = [g1_generator()];
+    let poly = DensePolynomial::<4>::from_coefficients_slice(&[u256::from(3u8)]).unwrap();
+
+    let commitment = kzg_commit(&poly, &srs).unwrap();
+
+    // 3*G
+    let expected = g1_three();
+    assert_eq!(commitment, expected);
+}
+
+/// KZG with two coefficients: C = a0*G1 + a1*G2.
+#[test]
+fn kzg_two_coefficients() {
+    let srs = [g1_generator(), g1_two()];
+    let poly =
+        DensePolynomial::<4>::from_coefficients_slice(&[u256::from(2u8), u256::from(1u8)]).unwrap();
+
+    let commitment = kzg_commit(&poly, &srs).unwrap();
+
+    // 2*G + 1*(2*G) = 2*G + 2*G = 4*G
+    let two_g = g1_two();
+    let expected = two_g.add(&two_g);
+    assert_eq!(commitment, expected);
+}
+
+/// KZG with zero polynomial returns the group identity.
+#[test]
+fn kzg_zero_polynomial() {
+    let srs = [g1_generator()];
+    let poly = DensePolynomial::<4>::zero();
+
+    let commitment = kzg_commit(&poly, &srs).unwrap();
+
+    // Identity: (0, 0)
+    assert_eq!(commitment.x, u256::from(0u8));
+    assert_eq!(commitment.y, u256::from(0u8));
+}
+
+/// KZG returns error when polynomial is longer than SRS.
+#[test]
+fn kzg_rejects_polynomial_exceeding_srs_length() {
+    let srs = [g1_generator()];
+    let poly =
+        DensePolynomial::<4>::from_coefficients_slice(&[u256::from(1u8), u256::from(1u8)]).unwrap();
+
+    assert_eq!(kzg_commit(&poly, &srs), Err(ZkError::InvalidInput));
+}
+
+/// KZG with constant polynomial (degree 0): C = a0 * G.
+#[test]
+fn kzg_constant_polynomial() {
+    let srs = [g1_generator()];
+    let poly = DensePolynomial::<4>::from_coefficients_slice(&[u256::from(5u8)]).unwrap();
+
+    let commitment = kzg_commit(&poly, &srs).unwrap();
+
+    // 5*G = 2*G + 3*G
+    let expected = g1_two().add(&g1_three());
+    assert_eq!(commitment, expected);
+}
+
+/// KZG with all-zero coefficients (trailing zeros stripped) behaves same as shorter polynomial.
+#[test]
+fn kzg_trailing_zeros_stripped() {
+    let srs = [g1_generator(), g1_two()];
+    let poly =
+        DensePolynomial::<4>::from_coefficients_slice(&[u256::from(1u8), u256::from(0u8)]).unwrap();
+
+    let commitment = kzg_commit(&poly, &srs).unwrap();
+
+    // Only a0=1 matters: C = 1*G
+    let expected = g1_generator();
+    assert_eq!(commitment, expected);
+}
+
+/// KZG is linear: commit(f + g) == commit(f) + commit(g).
+#[test]
+fn kzg_linearity() {
+    let srs = [g1_generator(), g1_two()];
+
+    let poly_a =
+        DensePolynomial::<4>::from_coefficients_slice(&[u256::from(1u8), u256::from(2u8)]).unwrap();
+    let poly_b =
+        DensePolynomial::<4>::from_coefficients_slice(&[u256::from(3u8), u256::from(4u8)]).unwrap();
+
+    let commit_a = kzg_commit(&poly_a, &srs).unwrap();
+    let commit_b = kzg_commit(&poly_b, &srs).unwrap();
+    let expected = commit_a.add(&commit_b);
+
+    // f + g = [4, 6]
+    let poly_sum =
+        DensePolynomial::<4>::from_coefficients_slice(&[u256::from(4u8), u256::from(6u8)]).unwrap();
+    let commit_sum = kzg_commit(&poly_sum, &srs).unwrap();
+
+    assert_eq!(commit_sum, expected);
+}
+
+/// KZG is homomorphic: commit(c * f) == c * commit(f).
+#[test]
+fn kzg_homomorphism() {
+    let srs = [g1_generator(), g1_two()];
+
+    let poly =
+        DensePolynomial::<4>::from_coefficients_slice(&[u256::from(2u8), u256::from(3u8)]).unwrap();
+    let scalar = u256::from(4u8);
+
+    let commit_f = kzg_commit(&poly, &srs).unwrap();
+    let expected = Bn254::g1_scalar_mul(G1Projective::from(commit_f), scalar).to_affine();
+
+    // scalar * poly = [8, 12]
+    let poly_scaled =
+        DensePolynomial::<4>::from_coefficients_slice(&[u256::from(8u8), u256::from(12u8)])
+            .unwrap();
+    let commit_scaled = kzg_commit(&poly_scaled, &srs).unwrap();
+
+    assert_eq!(commit_scaled, expected);
+}


### PR DESCRIPTION
## Description

This PR adds standalone KZG commitment generation to `soroban-zk-core` by implementing multi-scalar multiplication (MSM) over polynomial coefficients and SRS G1 points.

### Changes

* Added `kzg_commit<const N: usize>()` to `crates/soroban-zk-core/src/lib.rs`
* Computes KZG commitments as the MSM of polynomial coefficients against the provided SRS
* Reuses the existing BN254 primitives (`G1Projective::identity()`, `g1_scalar_mul()`, and group addition)
* Accumulates in projective coordinates and converts to affine once at the end
* Returns an error when the polynomial exceeds the available SRS length
* Added 8 KAT/property tests covering:

  * Single coefficient commitment
  * Multiple coefficient commitment
  * Constant polynomial
  * Zero polynomial
  * Polynomial/SRS length validation
  * Trailing zero coefficients
  * Linearity
  * Homomorphism
* Added `bench_kzg_commit` benchmark cases for size 2 and size 4 polynomials

### Implementation Notes

* Zero heap allocations in the commitment path
* Fully `no_std` compatible
* Reuses existing curve operations without introducing new cryptographic dependencies or MSM algorithms
* No API-breaking changes

## Linked Issue

Fixes #112

## Mathematical/Cryptographic Impact

Introduces native KZG commitment generation for `soroban-zk-core`, computing commitments as:

`C = Σ(aᵢ · [τⁱ])`

where polynomial coefficients are multiplied by their corresponding SRS G1 points and accumulated using projective coordinates for correctness and efficiency.

## Verification

* [x] `cargo fmt --all -- --check`
* [x] `cargo clippy --all-targets --all-features -- -D warnings`
* [x] `cargo test -p soroban-zk-core --release`
* [x] `cargo build --target wasm32v1-none --release -p verifier-sample`

## PR Checklist

* [x] I have run `make all` locally and everything passes.
* [x] My code strictly adheres to `no_std` (no standard library imports).
* [x] I have added tests that prove my fix is effective or that my feature works.
* [x] I have not introduced any `.unwrap()` or `panic!()` calls (using custom errors instead).
* [x] My changes do not push the core WASM binary over the 64KB limit.
