### PR TITLE
fix(security): bind public inputs to transaction parameters

### DIFF
--- a/hackathon-demo/contracts/shielded-asset/src/lib.rs
+++ b/hackathon-demo/contracts/shielded-asset/src/lib.rs
@@ -5,6 +5,7 @@ use soroban_sdk::{contract, contractimpl, contracttype, Address, Bytes, Env};
 use soroban_zk_core::G1Affine;
 use soroban_zk_std::groth16::{groth16_verify, Groth16Proof, Groth16VerifyingKey};
 use soroban_zk_std::pairing::G2Affine;
+use soroban_zk_std::poseidon2::hash_to_field;
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -51,11 +52,65 @@ impl ShieldedAsset {
         let vk = get_verifying_key();
 
         // ── 5. VERIFY with soroban-zk-std ────────────────────────────────────
-        // public_inputs_bytes carries the caller-supplied public input scalar.
-        // Binding it to the actual transaction parameters is handled in #337;
-        // here we simply pass it through so verification is no longer skipped.
+        // Bind the first public input to the actual transaction parameters so
+        // a proof generated for one (sender, receiver, amount) triple cannot be
+        // replayed against a different one.
+        //
+        // Expected public input:
+        //   H = Poseidon2(sender_fe || receiver_fe || amount_fe)
+        //
+        // Encoding (each value zero-padded to a 32-byte BN254 Fr element):
+        //   sender_fe  : right-aligned ASCII bytes of the Stellar address (≤56 chars)
+        //   receiver_fe: right-aligned ASCII bytes of the Stellar address (≤56 chars)
+        //   amount_fe  : (amount as u128) in big-endian, zero-padded to 32 bytes
+        //
+        // The off-chain prover must use the same commitment so that any mismatch
+        // between the proof's public input and the on-chain parameters is caught
+        // by groth16_verify below.
+        if public_inputs_bytes.len() < 32 {
+            panic!("public_inputs_bytes too short: expected at least 32 bytes");
+        }
+
+        // Encode sender address.
+        let sender_raw = sender.to_string().to_bytes();
+        let sender_len = sender_raw.len().min(32) as usize;
+        let mut sender_padded = [0u8; 32];
+        {
+            let mut tmp = [0u8; 56]; // Stellar addresses are at most 56 chars
+            sender_raw.copy_into_slice(&mut tmp[..sender_raw.len() as usize]);
+            sender_padded[32 - sender_len..].copy_from_slice(&tmp[..sender_len]);
+        }
+
+        // Encode receiver address.
+        let receiver_raw = receiver.to_string().to_bytes();
+        let receiver_len = receiver_raw.len().min(32) as usize;
+        let mut receiver_padded = [0u8; 32];
+        {
+            let mut tmp = [0u8; 56];
+            receiver_raw.copy_into_slice(&mut tmp[..receiver_raw.len() as usize]);
+            receiver_padded[32 - receiver_len..].copy_from_slice(&tmp[..receiver_len]);
+        }
+
+        // Encode amount (i128 → u128 bit pattern, big-endian, zero-padded to 32 bytes).
+        let mut amount_padded = [0u8; 32];
+        amount_padded[16..].copy_from_slice(&(amount as u128).to_be_bytes());
+
+        let fe_sender   = soroban_sdk::U256::from_be_bytes(&env, &Bytes::from_array(&env, &sender_padded));
+        let fe_receiver = soroban_sdk::U256::from_be_bytes(&env, &Bytes::from_array(&env, &receiver_padded));
+        let fe_amount   = soroban_sdk::U256::from_be_bytes(&env, &Bytes::from_array(&env, &amount_padded));
+
+        let expected_pi = hash_to_field(&env, &[fe_sender, fe_receiver, fe_amount]);
+
+        // Read the first 32 bytes of the caller-supplied public input.
         let mut pi_buf = [0u8; 32];
         public_inputs_bytes.copy_into_slice(&mut pi_buf);
+        let supplied_pi_sdk = soroban_sdk::U256::from_be_bytes(&env, &Bytes::from_array(&env, &pi_buf));
+
+        if supplied_pi_sdk != expected_pi {
+            panic!("Public inputs do not match transaction parameters: possible proof replay attack");
+        }
+
+        // groth16_verify takes ethnum::u256; convert from the validated byte array.
         let public_input = u256::from_be_bytes(pi_buf);
 
         let is_valid = groth16_verify(&env, &vk, &proof, &[public_input])

--- a/hackathon-demo/contracts/shielded-asset/src/lib.rs
+++ b/hackathon-demo/contracts/shielded-asset/src/lib.rs
@@ -3,7 +3,7 @@
 use ethnum::u256;
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Bytes, Env};
 use soroban_zk_core::G1Affine;
-use soroban_zk_std::groth16::{groth16_verify as _, Groth16Proof, Groth16VerifyingKey};
+use soroban_zk_std::groth16::{groth16_verify, Groth16Proof, Groth16VerifyingKey};
 use soroban_zk_std::pairing::G2Affine;
 
 #[contracttype]
@@ -51,15 +51,21 @@ impl ShieldedAsset {
         let vk = get_verifying_key();
 
         // ── 5. VERIFY with soroban-zk-std ────────────────────────────────────
-        // NOTE: Commented out because testnet budget limit is currently too low for full verification
-        // let is_valid = groth16_verify(&env, &vk, &proof, &[public_input])
-        //    .expect("Verification failed due to malformed curve points");
+        // public_inputs_bytes carries the caller-supplied public input scalar.
+        // Binding it to the actual transaction parameters is handled in #337;
+        // here we simply pass it through so verification is no longer skipped.
+        let mut pi_buf = [0u8; 32];
+        public_inputs_bytes.copy_into_slice(&mut pi_buf);
+        let public_input = u256::from_be_bytes(pi_buf);
 
-        // if !is_valid {
-        //    panic!("ZK Proof is invalid! Transfer rejected by soroban-zk-std.");
-        // }
+        let is_valid = groth16_verify(&env, &vk, &proof, &[public_input])
+            .expect("Verification failed due to malformed curve points");
 
-        let _ = (&vk, &proof, &public_inputs_bytes); // suppress unused warnings until #336 and #337 land
+        if !is_valid {
+            panic!("ZK Proof is invalid! Transfer rejected by soroban-zk-std.");
+        }
+
+        let _ = &public_inputs_bytes; // consumed above; suppress any lint
 
         // ── 7. Update on-chain shielded balances ─────────────────────────────
         let mut sender_bal: i128 = env.storage().persistent().get(&sender).unwrap_or(0);

--- a/hackathon-demo/contracts/shielded-asset/src/lib.rs
+++ b/hackathon-demo/contracts/shielded-asset/src/lib.rs
@@ -3,7 +3,7 @@
 use ethnum::u256;
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Bytes, Env};
 use soroban_zk_core::G1Affine;
-use soroban_zk_std::groth16::{groth16_verify, Groth16Proof, Groth16VerifyingKey};
+use soroban_zk_std::groth16::{groth16_verify as _, Groth16Proof, Groth16VerifyingKey};
 use soroban_zk_std::pairing::G2Affine;
 
 #[contracttype]
@@ -25,10 +25,6 @@ impl ShieldedAsset {
     ///   1. Sender has sufficient shielded balance.
     ///   2. The amount committed to by the proof matches the on-chain state.
     ///   3. Values are in range (no negative amounts).
-    ///
-    /// HACKATHON DEMO BYPASS: If proof_bytes is all 0x00, verification is
-    /// skipped so the UI demo can submit real on-chain transactions without
-    /// a full proving circuit. In production, remove the bypass entirely.
     pub fn transfer_shielded(
         env: Env,
         sender: Address,
@@ -46,26 +42,24 @@ impl ShieldedAsset {
         let mut proof_buf = [0u8; 256];
         proof_bytes.copy_into_slice(&mut proof_buf);
 
-        // ── HACKATHON DEMO BYPASS ───────────────────────────────────────────
-        let is_bypass = proof_buf.iter().all(|&b| b == 0);
-        
-        if !is_bypass {
-            // ── 2. Parse the proof with soroban-zk-std ───────────────────────
-            let proof = Groth16Proof::from_bytes(&proof_buf)
-                .expect("Malformed Groth16 proof bytes");
+        // ── 2. Parse the proof with soroban-zk-std ───────────────────────────
+        // All proofs must be fully verified — there is no bypass path.
+        let proof = Groth16Proof::from_bytes(&proof_buf)
+            .expect("Malformed Groth16 proof bytes");
 
-            // ── 3. Load the verifying key ────────────────────────────────────
-            let vk = get_verifying_key();
+        // ── 3. Load the verifying key ─────────────────────────────────────────
+        let vk = get_verifying_key();
 
-            // ── 5. VERIFY with soroban-zk-std ────────────────────────────────
-            // NOTE: Commented out because testnet budget limit is currently too low for full verification
-            // let is_valid = groth16_verify(&env, &vk, &proof, &[public_input])
-            //    .expect("Verification failed due to malformed curve points");
+        // ── 5. VERIFY with soroban-zk-std ────────────────────────────────────
+        // NOTE: Commented out because testnet budget limit is currently too low for full verification
+        // let is_valid = groth16_verify(&env, &vk, &proof, &[public_input])
+        //    .expect("Verification failed due to malformed curve points");
 
-            // if !is_valid {
-            //    panic!("ZK Proof is invalid! Transfer rejected by soroban-zk-std.");
-            // }
-        }
+        // if !is_valid {
+        //    panic!("ZK Proof is invalid! Transfer rejected by soroban-zk-std.");
+        // }
+
+        let _ = (&vk, &proof, &public_inputs_bytes); // suppress unused warnings until #336 and #337 land
 
         // ── 7. Update on-chain shielded balances ─────────────────────────────
         let mut sender_bal: i128 = env.storage().persistent().get(&sender).unwrap_or(0);


### PR DESCRIPTION
## Closes #337

Stacks on #344 and #345 — merge those first.

## Problem

`public_inputs_bytes` was accepted as a parameter but never validated against the actual `sender`, `receiver`, and `amount`. A proof generated for 1 XLM could be replayed to claim 1,000,000 XLM by supplying the correct proof bytes with mismatched public inputs.

## Fix

Derive the expected first public input on-chain as:

```
H = Poseidon2(sender_fe || receiver_fe || amount_fe)
```

using `soroban_zk_std::poseidon2::hash_to_field` (CAP-0075 host function). The contract panics if the caller-supplied value does not equal `H`, so any proof generated for a different transfer triple is rejected before `groth16_verify` is reached.

## Encoding Convention

| Field | Representation |
|---|---|
| `sender_fe` | ASCII bytes of Stellar G-address, right-aligned in 32 bytes |
| `receiver_fe` | ASCII bytes of Stellar G-address, right-aligned in 32 bytes |
| `amount_fe` | `amount as u128`, big-endian, zero-padded to 32 bytes |

The off-chain prover must produce a proof whose first public output equals this hash for the transfer to be accepted.