### PR TITLE
fix(poseidon2): avoid overflow panic in field addition

### DIFF
--- a/crates/soroban-zk-std/src/poseidon2.rs
+++ b/crates/soroban-zk-std/src/poseidon2.rs
@@ -42,7 +42,13 @@ fn u(env: &Env, hi: u128, lo: u128) -> U256 {
 /// Both inputs must be < r. The modulus is passed in so callers can reuse a
 /// cached value instead of rebuilding it on every addition.
 fn field_add(a: &U256, b: &U256, modulus: &U256) -> U256 {
-    let sum = a.add(b);
+    // Soroban U256 addition can panic if the sum exceeds the 256-bit range.
+    // Reduce each operand modulo the field modulus first, then add the reduced
+    // values. Since each operand is now < modulus, their sum is always safe.
+    let a_mod = if a >= modulus { a.sub(modulus) } else { a.clone() };
+    let b_mod = if b >= modulus { b.sub(modulus) } else { b.clone() };
+
+    let sum = a_mod.add(&b_mod);
     if sum >= *modulus {
         sum.sub(modulus)
     } else {
@@ -731,6 +737,18 @@ mod tests {
                 0xe660b145994427cc86296242cf766ec8
             )
         );
+    }
+
+    #[test]
+    fn field_add_reduces_when_sum_exceeds_modulus() {
+        let env = env();
+        let modulus = fr_modulus(&env);
+        let a = modulus.clone().sub(&U256::from_u128(&env, 1));
+        let b = U256::from_u128(&env, 2);
+
+        let result = field_add(&a, &b, &modulus);
+
+        assert_eq!(result, U256::from_u128(&env, 1));
     }
 
     #[test]

--- a/crates/soroban-zk-std/test_snapshots/tests/poseidon2_hash_matches_uncached_and_reuses_cache.1.json
+++ b/crates/soroban-zk-std/test_snapshots/tests/poseidon2_hash_matches_uncached_and_reuses_cache.1.json
@@ -11,7 +11,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 26,
+    "protocol_version": 27,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",


### PR DESCRIPTION
# Fix Poseidon2 field addition overflow panic

## Summary
This change fixes a potential panic in Poseidon2 field addition by avoiding direct `U256` addition on values that can exceed the 256-bit range before modular reduction.

## What changed
- Updated the Poseidon2 field addition helper to reduce operands modulo the BN254 field modulus before adding them
- Added a regression test covering the case where the sum would exceed the modulus
- Verified the Poseidon2-related test suite passes

## Verification
- Ran `cargo test -p soroban-zk-std poseidon2 -- --nocapture`
- Result: 13 tests passed, 0 failed

#Closes: #330 